### PR TITLE
Fix three-tier config precedence and add comprehensive subtitle CLI/env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,38 @@ FREESOUND_CLIENT_SECRET=your_freesound_client_secret_here
 FREESOUND_REFRESH_TOKEN=your_freesound_refresh_token_here
 
 # =============================================================================
+# SUBTITLE CONFIGURATION (OPTIONAL)
+# =============================================================================
+
+# Subtitle positioning
+# SUBTITLE_ANCHOR=bottom                  # Options: top, center, bottom, above_content, below_content
+# SUBTITLE_MARGIN=0.05                    # Margin as fraction of frame height (0.0-0.5)
+# SUBTITLE_CONTENT_AWARE=true             # Enable content-aware positioning
+
+# Subtitle styling
+# SUBTITLE_STYLE_PRESET=modern            # Options: minimal, modern, bold, animated, random
+# SUBTITLE_FONT_SIZE_SCALE=1.0            # Font size scale factor (0.5-2.0)
+# SUBTITLE_ALIGNMENT=center               # Options: left, center, right
+# SUBTITLE_MAX_WIDTH_FRACTION=0.9         # Max width as fraction of frame (0.0-1.0)
+
+# Subtitle randomization (for 'random' preset)
+# SUBTITLE_RANDOMIZE_FONTS=false          # Enable font randomization
+# SUBTITLE_RANDOMIZE_COLORS=false         # Enable color randomization
+# SUBTITLE_RANDOMIZE_EFFECTS=false        # Enable effect randomization
+
+# Subtitle text formatting
+# SUBTITLE_MAX_LINE_LENGTH=42             # Maximum characters per line
+# SUBTITLE_MAX_WORDS_PER_LINE=8           # Maximum words per line (0 to disable)
+# SUBTITLE_MAX_DURATION=5.0               # Maximum duration in seconds
+# SUBTITLE_MIN_DURATION=1.0               # Minimum duration in seconds
+
+# Advanced subtitle styling (ASS format colors: &H00RRGGBB)
+# SUBTITLE_FONT=Montserrat                # Font family name
+# SUBTITLE_FONT_COLOR=&H00FFFFFF          # Text color
+# SUBTITLE_OUTLINE_COLOR=&H00000000       # Outline color
+# SUBTITLE_BACKGROUND_COLOR=&H00000000    # Background color
+
+# =============================================================================
 # ADVANCED CONFIGURATION (OPTIONAL)
 # =============================================================================
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -81,10 +81,11 @@ ContentEngineAI **MUST** use a three-tier configuration system with precedence:
 ### Profile-Specific Settings
 - **All visual settings MUST be configurable per video profile**
 - Image positioning and sizing settings (width, position, aspect ratio)
-- Subtitle positioning, styling, fonts, colors, and effects
-- Profile settings override global defaults through merging system
+- Subtitle positioning, styling, fonts, colors, and effects (19+ override fields in VideoProfile)
+- Profile settings override global defaults through merging system (`get_profile_merged_settings()`)
 - Maintain backward compatibility with existing global configuration
 - Support unified subtitle positioning system with anchor-based layout
+- Implementation: VideoProfile class fields (`subtitle_anchor`, `subtitle_margin`, etc.) with precedence: CLI > ENV > PROFILE > YAML
 
 ### Font & Color Management
 - **Style Preset System**: 5 predefined presets (minimal, modern, bold, animated, random)
@@ -129,7 +130,11 @@ ContentEngineAI **MUST** use a three-tier configuration system with precedence:
 ## Global Requirements
 
 ### Configuration & CLI
-- Three-tier precedence: CLI args > env vars > YAML config
+- **Three-tier precedence: CLI args > env vars > YAML config**
+  - CLI arguments: 20+ subtitle flags (`--subtitle-anchor`, `--preset`, `--randomize-fonts`, etc.)
+  - Environment variables: 17 subtitle env vars (`SUBTITLE_ANCHOR`, `SUBTITLE_STYLE_PRESET`, etc.)
+  - YAML config: Default values in `config/subtitles.yaml`
+  - Implementation: `load_video_config_modular(cli_overrides={...})` with `ConfigManager.apply_precedence_rules()`
 - CLI arguments override all other configuration sources
 - Global debug mode across all components
 - Validate configuration at startup with clear error messages

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -81,11 +81,10 @@ ContentEngineAI **MUST** use a three-tier configuration system with precedence:
 ### Profile-Specific Settings
 - **All visual settings MUST be configurable per video profile**
 - Image positioning and sizing settings (width, position, aspect ratio)
-- Subtitle positioning, styling, fonts, colors, and effects (19+ override fields in VideoProfile)
-- Profile settings override global defaults through merging system (`get_profile_merged_settings()`)
+- Subtitle positioning, styling, fonts, colors, and effects
+- Profile settings override global defaults through merging system
 - Maintain backward compatibility with existing global configuration
 - Support unified subtitle positioning system with anchor-based layout
-- Implementation: VideoProfile class fields (`subtitle_anchor`, `subtitle_margin`, etc.) with precedence: CLI > ENV > PROFILE > YAML
 
 ### Font & Color Management
 - **Style Preset System**: 5 predefined presets (minimal, modern, bold, animated, random)
@@ -130,12 +129,9 @@ ContentEngineAI **MUST** use a three-tier configuration system with precedence:
 ## Global Requirements
 
 ### Configuration & CLI
-- **Three-tier precedence: CLI args > env vars > YAML config**
-  - CLI arguments: 20+ subtitle flags (`--subtitle-anchor`, `--preset`, `--randomize-fonts`, etc.)
-  - Environment variables: 17 subtitle env vars (`SUBTITLE_ANCHOR`, `SUBTITLE_STYLE_PRESET`, etc.)
-  - YAML config: Default values in `config/subtitles.yaml`
-  - Implementation: `load_video_config_modular(cli_overrides={...})` with `ConfigManager.apply_precedence_rules()`
+- Three-tier precedence: CLI args > env vars > YAML config
 - CLI arguments override all other configuration sources
+- Environment variables for all major configuration settings
 - Global debug mode across all components
 - Validate configuration at startup with clear error messages
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -66,6 +66,31 @@ class UnifiedConfigManager:
             # Performance overrides
             "CONTENT_ENGINE_TIMEOUT": ["pipeline_timeout_sec"],
             "FFMPEG_THREADS": ["ffmpeg_settings.encoding.threads"],
+            # Subtitle positioning
+            "SUBTITLE_ANCHOR": ["subtitle_settings.anchor"],
+            "SUBTITLE_MARGIN": ["subtitle_settings.margin"],
+            "SUBTITLE_CONTENT_AWARE": ["subtitle_settings.content_aware"],
+            # Subtitle styling
+            "SUBTITLE_STYLE_PRESET": ["subtitle_settings.style_preset"],
+            "SUBTITLE_FONT_SIZE_SCALE": ["subtitle_settings.font_size_scale"],
+            "SUBTITLE_ALIGNMENT": ["subtitle_settings.horizontal_alignment"],
+            "SUBTITLE_MAX_WIDTH_FRACTION": [
+                "subtitle_settings.max_subtitle_width_fraction"
+            ],
+            # Subtitle randomization
+            "SUBTITLE_RANDOMIZE_FONTS": ["subtitle_settings.randomize_fonts"],
+            "SUBTITLE_RANDOMIZE_COLORS": ["subtitle_settings.randomize_colors"],
+            "SUBTITLE_RANDOMIZE_EFFECTS": ["subtitle_settings.randomize_effects"],
+            # Subtitle text formatting
+            "SUBTITLE_MAX_LINE_LENGTH": ["subtitle_settings.max_line_length"],
+            "SUBTITLE_MAX_WORDS_PER_LINE": ["subtitle_settings.max_words_per_line"],
+            "SUBTITLE_MAX_DURATION": ["subtitle_settings.max_duration"],
+            "SUBTITLE_MIN_DURATION": ["subtitle_settings.min_duration"],
+            # Advanced subtitle styling
+            "SUBTITLE_FONT": ["subtitle_settings.font_name"],
+            "SUBTITLE_FONT_COLOR": ["subtitle_settings.font_color"],
+            "SUBTITLE_OUTLINE_COLOR": ["subtitle_settings.outline_color"],
+            "SUBTITLE_BACKGROUND_COLOR": ["subtitle_settings.background_color"],
         }
 
         for env_var, config_paths in env_mappings.items():

--- a/src/video/producer.py
+++ b/src/video/producer.py
@@ -1643,6 +1643,93 @@ def discover_products_for_batch(outputs_dir: Path) -> list[tuple[Path, ProductDa
     return products
 
 
+def _build_cli_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    """Build CLI overrides dictionary from parsed arguments.
+
+    Args:
+    ----
+        args: Parsed command-line arguments
+
+    Returns:
+    -------
+        Dictionary mapping config paths to override values
+
+    """
+    overrides: dict[str, Any] = {}
+
+    # Subtitle format and effects (legacy args)
+    if args.subtitle_format:
+        overrides["subtitle_settings.subtitle_format"] = args.subtitle_format
+    if args.ass_karaoke:
+        overrides["subtitle_settings.ass_enable_karaoke"] = True
+    if args.ass_fade:
+        overrides["subtitle_settings.ass_enable_fade"] = True
+    if args.preset:
+        overrides["subtitle_settings.style_preset"] = args.preset
+
+    # Positioning
+    if args.subtitle_anchor:
+        overrides["subtitle_settings.anchor"] = args.subtitle_anchor
+    if args.subtitle_margin is not None:
+        overrides["subtitle_settings.margin"] = args.subtitle_margin
+    if (
+        hasattr(args, "subtitle_content_aware")
+        and args.subtitle_content_aware is not None
+    ):
+        overrides["subtitle_settings.content_aware"] = args.subtitle_content_aware
+
+    # Styling
+    if args.font_size_scale is not None:
+        overrides["subtitle_settings.font_size_scale"] = args.font_size_scale
+    if args.max_subtitle_width_fraction is not None:
+        overrides["subtitle_settings.max_subtitle_width_fraction"] = (
+            args.max_subtitle_width_fraction
+        )
+    if args.subtitle_alignment:
+        overrides["subtitle_settings.horizontal_alignment"] = args.subtitle_alignment
+
+    # Text formatting
+    if args.max_line_length is not None:
+        overrides["subtitle_settings.max_line_length"] = args.max_line_length
+    if args.max_words_per_line is not None:
+        overrides["subtitle_settings.max_words_per_line"] = args.max_words_per_line
+    if args.max_duration is not None:
+        overrides["subtitle_settings.max_duration"] = args.max_duration
+    if args.min_duration is not None:
+        overrides["subtitle_settings.min_duration"] = args.min_duration
+
+    # Randomization
+    if (
+        hasattr(args, "subtitle_randomize_fonts")
+        and args.subtitle_randomize_fonts is not None
+    ):
+        overrides["subtitle_settings.randomize_fonts"] = args.subtitle_randomize_fonts
+    if (
+        hasattr(args, "subtitle_randomize_colors")
+        and args.subtitle_randomize_colors is not None
+    ):
+        overrides["subtitle_settings.randomize_colors"] = args.subtitle_randomize_colors
+    if (
+        hasattr(args, "subtitle_randomize_effects")
+        and args.subtitle_randomize_effects is not None
+    ):
+        overrides["subtitle_settings.randomize_effects"] = (
+            args.subtitle_randomize_effects
+        )
+
+    # Advanced styling
+    if args.subtitle_font:
+        overrides["subtitle_settings.font_name"] = args.subtitle_font
+    if args.subtitle_font_color:
+        overrides["subtitle_settings.font_color"] = args.subtitle_font_color
+    if args.subtitle_outline_color:
+        overrides["subtitle_settings.outline_color"] = args.subtitle_outline_color
+    if args.subtitle_background_color:
+        overrides["subtitle_settings.background_color"] = args.subtitle_background_color
+
+    return overrides
+
+
 async def main():
     parser = argparse.ArgumentParser(
         description="Generate promotional videos for e-commerce products."
@@ -1718,6 +1805,126 @@ async def main():
         choices=["minimal", "modern", "bold", "animated", "random"],
         help="Override subtitle style preset: minimal, modern, bold, animated, random.",
     )
+
+    # Subtitle positioning arguments
+    parser.add_argument(
+        "--subtitle-anchor",
+        choices=["top", "center", "bottom", "above_content", "below_content"],
+        help="Subtitle anchor position.",
+    )
+    parser.add_argument(
+        "--subtitle-margin",
+        type=float,
+        help="Subtitle margin as fraction of frame height (0.0-0.5).",
+    )
+    parser.add_argument(
+        "--content-aware",
+        action="store_true",
+        dest="subtitle_content_aware",
+        help="Enable content-aware subtitle positioning.",
+    )
+    parser.add_argument(
+        "--no-content-aware",
+        action="store_false",
+        dest="subtitle_content_aware",
+        help="Disable content-aware subtitle positioning.",
+    )
+
+    # Subtitle styling arguments
+    parser.add_argument(
+        "--font-size-scale",
+        type=float,
+        help="Font size scale factor (0.5-2.0).",
+    )
+    parser.add_argument(
+        "--max-subtitle-width-fraction",
+        type=float,
+        help="Max subtitle width as fraction of frame width (0.0-1.0).",
+    )
+    parser.add_argument(
+        "--subtitle-alignment",
+        choices=["left", "center", "right"],
+        help="Horizontal text alignment.",
+    )
+
+    # Subtitle text formatting arguments
+    parser.add_argument(
+        "--max-line-length",
+        type=int,
+        help="Maximum characters per subtitle line.",
+    )
+    parser.add_argument(
+        "--max-words-per-line",
+        type=int,
+        help="Maximum words per subtitle line (0 to disable).",
+    )
+    parser.add_argument(
+        "--max-duration",
+        type=float,
+        help="Maximum subtitle duration in seconds.",
+    )
+    parser.add_argument(
+        "--min-duration",
+        type=float,
+        help="Minimum subtitle duration in seconds.",
+    )
+
+    # Randomization arguments
+    parser.add_argument(
+        "--randomize-fonts",
+        action="store_true",
+        dest="subtitle_randomize_fonts",
+        help="Enable font randomization.",
+    )
+    parser.add_argument(
+        "--no-randomize-fonts",
+        action="store_false",
+        dest="subtitle_randomize_fonts",
+        help="Disable font randomization.",
+    )
+    parser.add_argument(
+        "--randomize-colors",
+        action="store_true",
+        dest="subtitle_randomize_colors",
+        help="Enable color randomization.",
+    )
+    parser.add_argument(
+        "--no-randomize-colors",
+        action="store_false",
+        dest="subtitle_randomize_colors",
+        help="Disable color randomization.",
+    )
+    parser.add_argument(
+        "--randomize-effects",
+        action="store_true",
+        dest="subtitle_randomize_effects",
+        help="Enable effect randomization.",
+    )
+    parser.add_argument(
+        "--no-randomize-effects",
+        action="store_false",
+        dest="subtitle_randomize_effects",
+        help="Disable effect randomization.",
+    )
+
+    # Advanced subtitle styling (colors and fonts)
+    parser.add_argument(
+        "--subtitle-font",
+        help="Override subtitle font family.",
+    )
+    parser.add_argument(
+        "--subtitle-font-color",
+        help="Override subtitle text color (ASS format: &H00RRGGBB).",
+    )
+    parser.add_argument(
+        "--subtitle-outline-color",
+        help="Override subtitle outline color (ASS format: &H00RRGGBB).",
+    )
+    parser.add_argument(
+        "--subtitle-background-color",
+        help="Override subtitle background color (ASS format: &H00RRGGBB).",
+    )
+
     args = parser.parse_args()
 
     # Validate argument combinations
@@ -1741,10 +1948,13 @@ async def main():
     project_root = Path(__file__).resolve().parent.parent.parent
     load_dotenv(project_root / ".env")
 
+    # Build CLI overrides dict from parsed arguments
+    cli_overrides = _build_cli_overrides(args)
+
     # Load config first to get log directory path
     try:
         # Use modular config loading (automatically handles modular vs monolithic)
-        config = load_video_config_modular()
+        config = load_video_config_modular(cli_overrides=cli_overrides)
     except Exception as e:
         # Fallback logging setup if config fails
         logging.basicConfig(
@@ -1766,22 +1976,11 @@ async def main():
         logger.critical(f"Complete log saved to: {log_file}")
         raise
 
-    # Apply CLI arguments to config
-    if args.subtitle_format:
-        config.subtitle_settings.subtitle_format = args.subtitle_format
-        logger.info(f"CLI override: subtitle_format = {args.subtitle_format}")
-
-    if args.ass_karaoke:
-        config.subtitle_settings.ass_enable_karaoke = True
-        logger.info("CLI override: ass_enable_karaoke = True")
-
-    if args.ass_fade:
-        config.subtitle_settings.ass_enable_fade = True
-        logger.info("CLI override: ass_enable_fade = True")
-
-    if args.preset:
-        config.subtitle_settings.style_preset = args.preset
-        logger.info(f"CLI override: style_preset = {args.preset}")
+    # Log applied CLI overrides (already applied via config loader)
+    if cli_overrides:
+        logger.info(f"Applied {len(cli_overrides)} CLI override(s):")
+        for key, value in cli_overrides.items():
+            logger.info(f"  {key} = {value}")
 
     try:
         secrets = {

--- a/src/video/unified_subtitle_generator.py
+++ b/src/video/unified_subtitle_generator.py
@@ -753,13 +753,15 @@ class UnifiedSubtitleGenerator:
                     selected_effects[effect] = True
                     logger.debug(f"Applied preset effect: {effect}")
             elif len(preset_effects) > 1:
-                # Violation: preset has multiple effects, use first one
-                effect = preset_effects[0]
-                if effect in selected_effects:
-                    selected_effects[effect] = True
-                logger.warning(
-                    f"Preset has {len(preset_effects)} effects, using first: {effect}"
+                # REQUIREMENTS.md violation: "exactly 1 effect per video"
+                preset_name = self.style_config.get("preset_name", "unknown")
+                msg = (
+                    f"Preset '{preset_name}' has {len(preset_effects)} effects. "
+                    f"REQUIREMENTS.md mandates exactly 1 effect per video. "
+                    f"Fix config/subtitles.yaml style_presets.{preset_name}.effects"
                 )
+                logger.error(msg)
+                raise ValueError(msg)
 
         return selected_effects
 


### PR DESCRIPTION
## Summary

Fixes broken three-tier configuration precedence system (CLI > ENV > YAML) and adds comprehensive CLI and environment variable support for subtitle configuration.

## Changes

### Configuration System
- **Fixed CLI precedence**: CLI overrides now properly passed to config loader
- **Added 20+ CLI arguments** for subtitle control:
  - Positioning: `--subtitle-anchor`, `--subtitle-margin`, `--content-aware`
  - Styling: `--font-size-scale`, `--subtitle-alignment`, `--max-subtitle-width-fraction`
  - Randomization: `--randomize-fonts`, `--randomize-colors`, `--randomize-effects`
  - Text formatting: `--max-line-length`, `--max-words-per-line`, `--max-duration`
  - Advanced: `--subtitle-font`, `--subtitle-font-color`, etc.

### Environment Variables
- **Added 17 subtitle environment variables**: `SUBTITLE_ANCHOR`, `SUBTITLE_STYLE_PRESET`, `SUBTITLE_RANDOMIZE_FONTS`, etc.
- Updated `.env.example` with comprehensive documentation

### Validation
- **Enforced single-effect rule**: Now raises `ValueError` instead of warning when presets violate "exactly 1 effect per video" requirement

### Code Quality
- Removed manual config assignments (now handled by precedence system)
- All changes pass linting (Ruff, MyPy) and tests

## Files Changed
- `src/video/producer.py`: CLI arguments and override builder
- `src/config_manager.py`: Environment variable mappings
- `src/video/unified_subtitle_generator.py`: Effect validation
- `.env.example`: Configuration documentation
- `REQUIREMENTS.md`: Updated requirements

## Testing
- ✅ Ruff linting
- ✅ MyPy type checking
- ✅ All tests passing