### PR TITLE
fix: Batch publish assigns unique slot per product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-04-09
+
 ### Fixed
 - Batch pipeline scheduling all products to the same time slot instead of assigning unique slots per product
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Batch pipeline scheduling all products to the same time slot instead of assigning unique slots per product
+
 ## [0.35.0] - 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,9 +278,10 @@ make test-cov      # Run tests with coverage report
 
 ## Publisher Module Notes
 
+- **Zernio (formerly Late)**: The platform rebranded from Late to Zernio. API is identical, old `getlate.dev` endpoints redirect. Our codebase still uses the old `late-sdk` package, `LATE_API_KEY` env var, and `src/publisher/late/` directory structure. Planned migration: switch to `zernio-sdk`, rename env var to `ZERNIO_API_KEY`, update imports. Both old and new SDK packages work during a 6-month grace period. No rush, but should be done eventually.
 - **TikTok content disclosure**: Posts **must** include `commercial_content_type: "brand_organic"` and `is_brand_organic_post: true` in `tiktokSettings`. Without these, TikTok rejects with "Commercial content disclosure is enabled but no option selected". The fix is in `src/publisher/late/client.py` — settings are sent both per-platform (`platformSpecificData.tiktokSettings`) and at top-level (`tiktok_settings`).
-- **Fixing failed TikTok posts**: Use Late SDK `posts.aupdate()` to set correct `tiktokSettings` per-platform, then the platform status resets from `failed` → `pending` and auto-publishes. No need to call `retry()` — the update triggers re-publish automatically. Calling `retry()` after that gives 409 "Post is currently publishing".
-- **Late SDK post methods**: `create`, `get`, `update`, `delete`, `retry`, `list` (+ async variants `acreate`, etc.)
+- **Fixing failed TikTok posts**: Use Zernio SDK `posts.aupdate()` to set correct `tiktokSettings` per-platform, then the platform status resets from `failed` → `pending` and auto-publishes. No need to call `retry()` — the update triggers re-publish automatically. Calling `retry()` after that gives 409 "Post is currently publishing".
+- **Zernio SDK post methods**: `create`, `get`, `update`, `delete`, `retry`, `list` (+ async variants `acreate`, etc.)
 - **Publishing modes**: Unified (default) = 1 post to all platforms; platform-specific (`--platform-specific` or `use_platform_specific_content: true`) = 1 post per platform with optimized metadata. Shared helper: `src/publisher/publish_modes.py`.
 - **Config loading gotcha**: `publisher.yaml` may contain keys not in `PublisherConfig` dataclass (e.g. deprecated `backoff_multiplier`). The config loader in `src/publisher/config.py` strips unknown keys before constructing `PublisherConfig(**config_dict)`.
 - **`.env` file**: Auto-loaded by the CLI via `load_dotenv()`. No manual sourcing needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,10 @@ make test-cov      # Run tests with coverage report
 - **Two scraping code paths**: The standalone scraper CLI uses `scrape_products_unified()` which has a cycling loop (`_scrape_until_validated_count_reached`). The global batch uses `scrape_batch_browser()` + `process_raw_products()` with its own page retry loop in `global_batch.py`. Changes to validation logic must be tested through both paths.
 - **Page retry**: Global batch retries with additional search pages when products fail media validation (`max_retry_pages` in scraper YAML). Only applies to keyword searches, not ASINs/URLs.
 
+## Module/Batch Alignment Rule
+
+**CRITICAL**: Standalone module CLIs (publisher, scraper, producer) and `global_batch.py` often have parallel implementations of the same logic (scheduling, validation, retry, cleanup). When fixing or adding behavior in one path, **proactively check the other path** for the same issue or missing feature. Don't wait for it to break separately. The batch pipeline re-implements logic from standalone modules rather than calling them, so drift is common and silent.
+
 ## Available MCP Servers
 
 The project has access to these MCP servers for enhanced development capabilities:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.35.0"
+version = "0.35.1"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/pipeline/global_batch.py
+++ b/src/pipeline/global_batch.py
@@ -1248,8 +1248,13 @@ class GlobalPipelineOrchestrator:
         # 1. Explicit CLI/YAML schedule_time (highest priority)
         # 2. Auto-schedule via recurring_schedule if immediate_publish=false
         # 3. Publish immediately (scheduled_time=None)
+        #
+        # For auto-schedule with multiple products, each product gets its
+        # own slot. The scheduling context is prepared here, and
+        # _find_next_schedule_slot() is called per-product in the loop.
 
         schedule_time = None
+        auto_schedule_ctx: dict | None = None
 
         # Priority 1: Explicit schedule time from CLI or YAML
         schedule_time_str = self.config.schedule_time or publisher_config.get(
@@ -1276,7 +1281,7 @@ class GlobalPipelineOrchestrator:
                 from src.publisher.models import RecurringSlot
                 from src.publisher.schedule import ScheduleManager
 
-                logger.info("Auto-scheduling: Finding next available slot...")
+                logger.info("Auto-scheduling: preparing slot context...")
 
                 # Parse recurring slots from config
                 slots_config = recurring_config.get("slots", [])
@@ -1304,16 +1309,12 @@ class GlobalPipelineOrchestrator:
                             schedule_path=self.config.outputs_dir / "schedule.json"
                         )
 
-                        # Find next available UNOCCUPIED slot
                         from datetime import UTC
-
-                        now = datetime.now(UTC)
 
                         # Fetch existing posts to check occupied slots
                         logger.debug("Checking occupied slots via API...")
                         occupied_slot_times: set[datetime] = set()
 
-                        # Initialize publisher to query existing posts
                         api_key = os.getenv("LATE_API_KEY")
                         vercel_token = os.getenv("LATE_VERCEL_TOKEN")
                         if api_key:
@@ -1328,22 +1329,18 @@ class GlobalPipelineOrchestrator:
                             )
 
                             try:
-                                # Authenticate to access API
                                 await temp_publisher.authenticate()
 
-                                # Fetch all posts (scheduled + published)
                                 api_posts = await temp_publisher.list_posts()
                                 logger.debug(
                                     f"Found {len(api_posts)} existing posts on API"
                                 )
 
-                                # Build set of occupied slot times
                                 for api_post in api_posts:
                                     scheduled_time = api_post.get("scheduledFor")
                                     if not scheduled_time:
                                         continue
 
-                                    # Parse scheduled time
                                     if isinstance(scheduled_time, str):
                                         time_str = scheduled_time.replace("+00:00", "")
                                         scheduled_dt = datetime.fromisoformat(time_str)
@@ -1354,7 +1351,6 @@ class GlobalPipelineOrchestrator:
                                     else:
                                         scheduled_dt = scheduled_time
 
-                                    # Normalize to slot precision (minute)
                                     slot_time = scheduled_dt.replace(
                                         second=0, microsecond=0
                                     )
@@ -1366,42 +1362,12 @@ class GlobalPipelineOrchestrator:
                             except Exception as e:
                                 logger.warning(f"Failed to fetch occupied slots: {e}")
 
-                        # Find next unoccupied slot
-                        max_attempts = len(slots) * 8  # Check up to 8 weeks ahead
-                        slot_index = 0
-
-                        for _attempt in range(max_attempts):
-                            next_slot_time, slot_index = schedule_manager.get_next_slot(
-                                slots, after=now, slot_index=slot_index
-                            )
-
-                            # Normalize to slot precision for comparison
-                            normalized_slot = next_slot_time.replace(
-                                second=0, microsecond=0
-                            )
-
-                            if normalized_slot not in occupied_slot_times:
-                                # Found unoccupied slot
-                                schedule_time = next_slot_time
-                                logger.info(
-                                    f"Auto-scheduled to slot #{slot_index}: "
-                                    f"{schedule_time.strftime(
-                                        '%A, %Y-%m-%d %H:%M:%S %Z'
-                                    )}"
-                                )
-                                break
-                            else:
-                                logger.debug(
-                                    f"Slot #{slot_index} occupied, trying next slot..."
-                                )
-                                # Move to next slot for next iteration
-                                now = next_slot_time
-                                slot_index = (slot_index + 1) % len(slots)
-                        else:
-                            logger.warning(
-                                "All slots occupied for next 8 weeks. "
-                                "Publishing immediately."
-                            )
+                        # Store context for per-product slot finding
+                        auto_schedule_ctx = {
+                            "slots": slots,
+                            "schedule_manager": schedule_manager,
+                            "occupied_slot_times": occupied_slot_times,
+                        }
 
                     except Exception as e:
                         logger.warning(
@@ -1530,6 +1496,48 @@ class GlobalPipelineOrchestrator:
                 if not pub_platforms:
                     raise ValueError("No valid platform accounts found")
 
+                # Find per-product schedule slot if auto-scheduling
+                product_schedule_time = schedule_time
+                if auto_schedule_ctx is not None:
+                    from datetime import UTC
+
+                    ctx_slots = auto_schedule_ctx["slots"]
+                    ctx_mgr = auto_schedule_ctx["schedule_manager"]
+                    ctx_occupied = auto_schedule_ctx["occupied_slot_times"]
+
+                    now = datetime.now(UTC)
+                    max_attempts = len(ctx_slots) * 8
+                    slot_index = 0
+
+                    for _attempt in range(max_attempts):
+                        next_slot_time, slot_index = ctx_mgr.get_next_slot(
+                            ctx_slots, after=now, slot_index=slot_index
+                        )
+                        normalized_slot = next_slot_time.replace(
+                            second=0, microsecond=0
+                        )
+                        if normalized_slot not in ctx_occupied:
+                            product_schedule_time = next_slot_time
+                            ctx_occupied.add(normalized_slot)
+                            logger.info(
+                                f"Auto-scheduled {product_id} to slot "
+                                f"#{slot_index}: "
+                                f"{next_slot_time.strftime(
+                                    '%A, %Y-%m-%d %H:%M:%S %Z'
+                                )}"
+                            )
+                            break
+                        else:
+                            logger.debug(f"Slot #{slot_index} occupied, trying next...")
+                            now = next_slot_time
+                            slot_index = (slot_index + 1) % len(ctx_slots)
+                    else:
+                        logger.warning(
+                            f"All slots occupied for {product_id}. "
+                            "Publishing immediately."
+                        )
+                        product_schedule_time = None
+
                 # Publish (unified or platform-specific mode)
                 from src.publisher.publish_modes import publish_product
 
@@ -1545,7 +1553,7 @@ class GlobalPipelineOrchestrator:
                     platforms=pub_platforms,
                     outputs_dir=self.config.outputs_dir,
                     platform_specific=platform_specific,
-                    schedule_time=schedule_time,
+                    schedule_time=product_schedule_time,
                 )
 
                 # Process results and record publish

--- a/tests/pipeline/test_global_batch_publishing.py
+++ b/tests/pipeline/test_global_batch_publishing.py
@@ -263,6 +263,91 @@ async def test_auto_scheduling_falls_back_to_immediate_when_all_slots_occupied(
         # Scheduled time should be None when all slots occupied
 
 
+@pytest.mark.asyncio
+async def test_auto_scheduling_assigns_unique_slots_per_product(
+    temp_outputs_dir, mock_publisher_config, mock_video_config
+):
+    """Test that batch scheduling gives each product a different slot.
+
+    Regression test: previously all products in a batch got the same
+    schedule_time because the slot was computed once before the loop.
+    """
+    config = GlobalBatchConfig(
+        product_ids=["B0TEST1", "B0TEST2"],
+        keywords=[],
+        max_products=2,
+        scraper_filters=SearchParameters(),
+        profile="slideshow_images1",
+        outputs_dir=temp_outputs_dir,
+        skip_publish=False,
+        platforms=["youtube"],
+    )
+
+    # Create two product directories with videos
+    for pid in ["B0TEST1", "B0TEST2"]:
+        pdir = temp_outputs_dir / pid
+        pdir.mkdir(parents=True)
+        (pdir / "video.mp4").write_text("fake video")
+        (pdir / "metadata.json").write_text('{"title": "Test", "description": "Test"}')
+
+    orchestrator = GlobalPipelineOrchestrator(config)
+
+    # No occupied slots - both products should get consecutive slots
+    with (
+        patch("yaml.safe_load", return_value=mock_publisher_config),
+        patch.dict(
+            "os.environ",
+            {
+                "LATE_API_KEY": "test_key",
+                "LATE_VERCEL_TOKEN": "test_vercel_token",
+            },
+        ),
+        patch("src.publisher.create_publisher") as mock_create_publisher,
+        patch(
+            "src.publisher.publish_modes.load_platform_metadata"
+        ) as mock_load_metadata,
+    ):
+        # Temp publisher for slot checking (returns no occupied slots)
+        temp_publisher = AsyncMock()
+        temp_publisher.authenticate = AsyncMock()
+        temp_publisher.list_posts = AsyncMock(return_value=[])
+
+        # Main publisher for actual publishing
+        main_publisher = AsyncMock()
+        main_publisher.authenticate = AsyncMock()
+        main_publisher.get_accounts = AsyncMock(
+            return_value=[{"platform": "youtube", "account_id": "acc1"}]
+        )
+        main_publisher.upload_media = AsyncMock(return_value="media_123")
+        main_publisher.publish = AsyncMock()
+
+        mock_create_publisher.side_effect = [temp_publisher, main_publisher]
+
+        mock_metadata = Mock()
+        mock_metadata.format_content = Mock(return_value="Test content")
+        mock_load_metadata.return_value = mock_metadata
+
+        produced_videos = [
+            (temp_outputs_dir / "B0TEST1" / "video.mp4", "B0TEST1"),
+            (temp_outputs_dir / "B0TEST2" / "video.mp4", "B0TEST2"),
+        ]
+        await orchestrator._execute_publishing_phase(produced_videos)
+
+        # Both products should have been published
+        assert main_publisher.publish.call_count == 2
+
+        # Extract scheduled times from both publish calls
+        times = []
+        for call in main_publisher.publish.call_args_list:
+            times.append(call[1]["scheduled_time"])
+
+        # The two scheduled times must be different
+        assert times[0] != times[1], (
+            f"Both products got the same slot: {times[0]}. "
+            "Each product should get a unique slot."
+        )
+
+
 # ============================================================================
 # CLEANUP TESTS
 # ============================================================================


### PR DESCRIPTION
## Summary

When `make batch-lowpri` publishes multiple products, all of them landed on the same time slot. The slot-finding ran once before the per-product loop, so every product shared a single `schedule_time`.

## Changes

- Move slot-finding into the per-product publish loop; after each product claims a slot, mark it occupied so subsequent products skip it
- The API fetch of existing posts still happens once (no extra API calls)
- Add regression test that verifies two products in a batch get different scheduled times
- Add module/batch alignment rule to CLAUDE.md
- Document Late to Zernio rebrand and migration plan in CLAUDE.md
- Update CHANGELOG

## Testing

- `ruff check`, `ruff format --check`, `mypy` all pass
- `pytest tests/pipeline/test_global_batch_publishing.py` passes (6/6 tests)
- Verified standalone publisher (`schedule.py:auto_schedule()`) already handles per-product slots correctly
