### PR TITLE
Add Whisper timing post-processing for smoother subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Whisper timing post-processing (`src/video/subtitle_timing_smoother.py`) that fixes coarse word timestamps before they reach either subtitle engine
+- Four smoothing rules: minimum word duration (120ms), gap merge (80ms), segment-end hold (+200ms), audio lead (40ms)
+- Configurable via `subtitle_settings.timing_smoothing` section in `subtitles.yaml`
+
 ## [0.36.0] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-04-14
+
 ### Added
 - Whisper timing post-processing (`src/video/subtitle_timing_smoother.py`) that fixes coarse word timestamps before they reach either subtitle engine
 - Four smoothing rules: minimum word duration (120ms), gap merge (80ms), segment-end hold (+200ms), audio lead (40ms)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ poetry run python tools/performance_report.py --report-type detailed --format cs
 - **LLM provider fallback**: Gemini is primary, OpenRouter is automatic fallback. Configured via `llm_settings.fallback_provider` in `ai_services.yaml` (self-referencing `LLMSettings`). Both `global_batch.py` and `cli.py` must include fallback provider's API key env var in the secrets dict. Shared dispatch in `src/ai/llm_client.py`
 - **LLM config fields**: `model_blocklist`, `min_context_length`, `retry_attempts`/`retry_min_wait_sec`/`retry_max_wait_sec`, and `script_validation` (min_chars, min_words) all live on `LLMSettings`. Don't hardcode these in generator code
 - **`.env` safety**: `update_env_file()` in `freesound_client.py` only updates existing keys, never adds new lines
+- **Timing smoother**: `src/video/subtitle_timing_smoother.py` post-processes raw Whisper word timestamps before either engine. Four rules: min duration 120ms, gap merge 80ms, segment-end hold +200ms, audio lead 40ms. Wired in `generate_subtitles_with_whisper` (single call site for both engines). Config: `subtitle_settings.timing_smoothing` nested dict in YAML, flows through `extra="allow"` on `MergedSubtitleSettings`. No flat Pydantic fields — the nested dict is passed directly to smoother kwargs.
 
 ### Pycaps Subtitle Engine Notes
 
@@ -198,12 +199,14 @@ After every context compaction (session continuation), run `/github-workflow` to
 - **CRITICAL: NEVER include `Co-Authored-By` trailers, author attributions, or any mention of Claude Code / AI tools / assistants**
 - Keep messages short and simple
 - Explain what and why, not how
+- Don't reference internal follow-up/todo docs (`docs/pycaps-followups.md`, `docs/subtitle-config-cleanup.md`, etc.) in commit messages. These are temporary working docs that may be removed or restructured.
 
 **Pull Request Descriptions**:
 - **CRITICAL: NEVER mention authors, Claude Code, AI tools, or assistants in PR titles or descriptions**
 - Keep descriptions short and simple
 - Use PR template if available in `.github/`
 - Focus on what changed, why it changed, and how to test
+- Don't reference internal follow-up/todo tracker docs in PR descriptions. Describe the change on its own terms.
 
 ## Development Workflow (GitHub Flow)
 

--- a/config/subtitles.yaml
+++ b/config/subtitles.yaml
@@ -86,6 +86,26 @@ subtitle_settings:
     # or "raise" (abort the pipeline).
     fallback_policy: "warn_and_skip"
 
+  # ---- TIMING SMOOTHER ----
+  # Post-processes raw Whisper word timestamps before they reach either
+  # the FFmpeg or pycaps subtitle engine. Fixes flickering, short-word
+  # flashes, and uneven segment durations from vanilla Whisper.
+  # See docs/subtitle-best-practices.md section 5 for the research.
+  timing_smoothing:
+    enabled: true
+    # Rule 1: minimum word duration (seconds). Words shorter than this
+    # are extended so they don't flash imperceptibly.
+    min_word_sec: 0.12
+    # Rule 2: inter-word gaps shorter than this (seconds) are absorbed
+    # into the preceding word to eliminate micro-flicker.
+    gap_merge_sec: 0.08
+    # Rule 3: extra hold time (seconds) added to the last word of each
+    # detected segment, so the caption lingers after speech ends.
+    hold_last_sec: 0.20
+    # Rule 4: lead time (seconds). Each word appears this far ahead of
+    # its audio onset so the viewer reads it just before hearing it.
+    lead_sec: 0.04
+
   # ---- UNIFIED POSITIONING SYSTEM ----
   # Content-aware positioning that automatically adapts to visual layout
   # This system ensures subtitles don't overlap with images/videos

--- a/docs/pycaps-followups.md
+++ b/docs/pycaps-followups.md
@@ -368,8 +368,7 @@ complains.
 
 **Priority**: high — affects BOTH engines, biggest single readability win.
 
-**Status**: not started. Raw Whisper timings flow straight from
-`stt_functions.py` to the subtitle generators without any smoothing.
+**Status**: **DONE** (PR #64, branch `feature/whisper-timing-smoothing`).
 
 ### Context
 
@@ -392,68 +391,35 @@ timings list.
 
 ### Acceptance criteria
 
-- [ ] New module `src/video/subtitle_timing_smoother.py` with a single
-  public function `smooth_word_timings(timings, config)` that applies
-  the four rules
-- [ ] Called from `src/video/subtitle_utils.py::create_unified_subtitles`
-  after STT returns, before the generator runs — affects BOTH engines
-- [ ] Config fields on `MergedSubtitleSettings`: `timing_min_word_sec`,
-  `timing_gap_merge_sec`, `timing_hold_last_sec`, `timing_lead_sec`,
-  all with the defaults above
-- [ ] Unit tests: empty input, single word, short gaps, normal sentence,
-  segment boundary hold
+- [x] New module `src/video/subtitle_timing_smoother.py` with two public
+  functions: `smooth_word_timings` (flat list for FFmpeg) and
+  `smooth_whisper_result_dict` (raw Whisper dict for pycaps)
+- [x] Called from `stt_functions.py::generate_subtitles_with_whisper`
+  after `_extract_word_timings`, before `save_whisper_transcript` —
+  single call site serves both engines
+- [x] Config in `config/subtitles.yaml` under `timing_smoothing` section
+  (nested dict, not flat Pydantic fields). Passed through to smoother
+  via `create_unified_subtitles` → `generate_subtitles_with_whisper`
+- [x] 18 unit tests: empty input, single word, short gaps, segment
+  boundary hold, gap merge, lead clamp, combined rules, custom params,
+  input immutability, Whisper dict path
 - [ ] Before/after fixture: same voiceover, same transcript, verify
   timing deltas are within the expected ranges
 
-### Implementation sketch
+### Implementation notes (what was actually built)
 
-```python
-# src/video/subtitle_timing_smoother.py
-def smooth_word_timings(
-    timings: list[dict[str, Any]],
-    min_word_sec: float = 0.12,
-    gap_merge_sec: float = 0.08,
-    hold_last_sec: float = 0.20,
-    lead_sec: float = 0.04,
-) -> list[dict[str, Any]]:
-    """Apply best-practice smoothing to raw STT word timings."""
-    if not timings:
-        return timings
-    out = [dict(t) for t in timings]
-    # Rule 4: lead
-    for t in out:
-        t["start_time"] = max(0.0, t["start_time"] - lead_sec)
-    # Rule 2: merge short gaps into the preceding word
-    for i in range(1, len(out)):
-        gap = out[i]["start_time"] - out[i - 1]["end_time"]
-        if 0 <= gap < gap_merge_sec:
-            out[i - 1]["end_time"] = out[i]["start_time"]
-    # Rule 1: clamp minimum word duration
-    for t in out:
-        dur = t["end_time"] - t["start_time"]
-        if dur < min_word_sec:
-            t["end_time"] = t["start_time"] + min_word_sec
-    # Rule 3: hold last word of each segment (detect via gaps > 0.4s)
-    # ... implementation detail
-    return out
-```
+Two public functions instead of one — the flat list and raw Whisper dict
+have different key names (`start_time`/`end_time` vs `start`/`end`), so
+smoothing both from a single call site in `generate_subtitles_with_whisper`
+was cleaner than trying to unify the shapes.
 
-### Risks and gotchas
+Config flows as a nested `timing_smoothing` dict from YAML through to the
+smoother kwargs. No flat Pydantic fields on `MergedSubtitleSettings` — the
+config audit caught that as dead code and they were removed.
 
-- The `generate_subtitles_with_whisper` function returns a flat list
-  `[{"word", "start_time", "end_time"}, ...]`. The raw-dict path used
-  by pycaps (`result_w["segments"][*]["words"]`) has a different shape.
-  Either (a) smooth at the flat-list layer and re-serialise the raw
-  dict from smoothed timings, or (b) smooth the raw dict directly and
-  re-extract the flat list. Option (b) is cleaner because it preserves
-  segment boundaries needed for rule 3.
-- **Don't smooth twice.** Wire it as the single entry point in
-  `create_unified_subtitles` and make sure neither the pycaps branch
-  nor the ffmpeg branch re-smooth.
-
-### Effort
-
-1 day. Simple logic, but needs tests and two config integration points.
+The before/after fixture test is still open — the unit tests cover the
+logic exhaustively, but a visual comparison on a real voiceover would
+confirm the perceptual improvement.
 
 ---
 
@@ -622,8 +588,8 @@ If you're picking one of these up and wondering where to start:
 
 - **Want to ship user-visible value**: do #1 (AI word tagging). It's the
   feature that sells the engine.
-- **Want the biggest readability win for the smallest code change**:
-  do #5 (timing smoothing). Affects BOTH engines.
+- ~~**Want the biggest readability win for the smallest code change**:
+  do #5 (timing smoothing). Affects BOTH engines.~~ **DONE** (PR #64).
 - **Want a fast win**: do #2 (mypy pin). 30 minutes, unblocks future
   dep bumps. Or #8 (drop `movement` effect), 1-2 hours.
 - **Want to reduce open risk**: do #3 (two-part hybrid). Fixes the one
@@ -637,15 +603,15 @@ If you're picking one of these up and wondering where to start:
 - **Want to keep CI honest**: do #4 (Chromium integration test). Safety
   net, not a feature.
 
-Suggested order: **#5 → #1 → #9 → #6 → #7 → #3 → #2 → #8 → #4**.
+Suggested order: **#1 → #9 → #6 → #7 → #3 → #2 → #8 → #4**.
 
-- #5 is foundational — all other rendering improvements depend on clean
-  timings
+- ~~#5 is foundational~~ — **DONE** (PR #64). Clean timings are now in
+  place for all downstream work
 - #1 enables #9 (emoji injection in the template)
 - #9 is the single most visible user-facing output
 - #3, #4, #7, #8 are hygiene/safety and can slot in at any point
 - #6 is the quality ceiling that makes everything else look better
 
 Nothing here is blocked on anything else, so items can be picked up in
-parallel. Items #5, #6, and #7 all benefit both engines — don't treat
-them as pycaps-specific just because they're tracked in this doc.
+parallel. Items #6 and #7 benefit both engines — don't treat them as
+pycaps-specific just because they're tracked in this doc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.36.0"
+version = "0.37.0"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/video/config/visual_models.py
+++ b/src/video/config/visual_models.py
@@ -538,13 +538,6 @@ class MergedSubtitleSettings(BaseModel):
     selected_font: str | None = None
     selected_color_pair: str | None = None
 
-    # Timing smoother (post-processes raw Whisper word timestamps)
-    timing_smoothing_enabled: bool = True
-    timing_min_word_sec: float = 0.12
-    timing_gap_merge_sec: float = 0.08
-    timing_hold_last_sec: float = 0.20
-    timing_lead_sec: float = 0.04
-
     # Two-part subtitle system (flat keys)
     two_part_subtitles_enabled: bool = False
     two_part_subtitles_upper_enabled: bool = True

--- a/src/video/config/visual_models.py
+++ b/src/video/config/visual_models.py
@@ -538,6 +538,13 @@ class MergedSubtitleSettings(BaseModel):
     selected_font: str | None = None
     selected_color_pair: str | None = None
 
+    # Timing smoother (post-processes raw Whisper word timestamps)
+    timing_smoothing_enabled: bool = True
+    timing_min_word_sec: float = 0.12
+    timing_gap_merge_sec: float = 0.08
+    timing_hold_last_sec: float = 0.20
+    timing_lead_sec: float = 0.04
+
     # Two-part subtitle system (flat keys)
     two_part_subtitles_enabled: bool = False
     two_part_subtitles_upper_enabled: bool = True

--- a/src/video/stt_functions.py
+++ b/src/video/stt_functions.py
@@ -62,6 +62,7 @@ async def generate_subtitles_with_whisper(
     script: str | None = None,
     debug_mode: bool = False,
     transcript_out_path: Path | None = None,
+    timing_smoothing_config: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]] | None:
     """Generate subtitle timing data using Whisper STT.
 
@@ -76,6 +77,11 @@ async def generate_subtitles_with_whisper(
             dict in ``whisper_json`` format. Used by the pycaps subtitle
             engine to consume word-level timings as the transcript source.
             Written unconditionally when set (not gated by ``debug_mode``).
+        timing_smoothing_config: Optional dict with timing smoother params
+            (``enabled``, ``min_word_sec``, ``gap_merge_sec``,
+            ``hold_last_sec``, ``lead_sec``). When ``None`` or
+            ``enabled=True`` (the default), smoothing runs with
+            best-practice defaults.
 
     Returns:
     -------
@@ -164,6 +170,30 @@ async def generate_subtitles_with_whisper(
             logger.warning("Whisper provided no usable word timings.")
             return None
         logger.info(f"Extracted {len(word_list_whisper)} word timings from Whisper.")
+
+        # Apply timing smoothing to fix Whisper's coarse word timestamps.
+        # Smooth both the flat list (for FFmpeg) and the raw dict (for pycaps).
+        ts_cfg = timing_smoothing_config or {}
+        if ts_cfg.get("enabled", True):
+            from src.video.subtitle_timing_smoother import (
+                smooth_whisper_result_dict,
+                smooth_word_timings,
+            )
+
+            smoother_kwargs = {
+                k: ts_cfg[k]
+                for k in (
+                    "min_word_sec",
+                    "gap_merge_sec",
+                    "hold_last_sec",
+                    "lead_sec",
+                )
+                if k in ts_cfg
+            }
+            word_list_whisper = smooth_word_timings(
+                word_list_whisper, **smoother_kwargs
+            )
+            result_w = smooth_whisper_result_dict(result_w, **smoother_kwargs)
 
         # Check if Whisper debug files should be created
         create_whisper_debug = debug_mode

--- a/src/video/subtitle_timing_smoother.py
+++ b/src/video/subtitle_timing_smoother.py
@@ -1,0 +1,165 @@
+"""Post-processing for raw Whisper word timings.
+
+Vanilla Whisper rounds word timestamps to whole seconds by default, producing
+flicker and uneven segment durations in karaoke-style captions. This module
+applies four best-practice smoothing rules (see docs/subtitle-best-practices.md
+section 5) to the flat word timing list *before* it reaches either the FFmpeg
+or pycaps subtitle engine.
+
+The rules are:
+1. Clamp minimum word duration (prevents imperceptible flashes)
+2. Merge inter-word gaps shorter than a threshold into the preceding word
+3. Hold the last word of each segment slightly past audio end
+4. Lead audio so the word appears just before it's spoken
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def smooth_word_timings(
+    timings: list[dict[str, Any]],
+    *,
+    min_word_sec: float = 0.12,
+    gap_merge_sec: float = 0.08,
+    hold_last_sec: float = 0.20,
+    lead_sec: float = 0.04,
+    segment_gap_threshold_sec: float = 0.40,
+) -> list[dict[str, Any]]:
+    """Apply best-practice smoothing to raw STT word timings.
+
+    Operates on the flat list format produced by ``_extract_word_timings``::
+
+        [{"word": "Hello", "start_time": 0.0, "end_time": 0.6}, ...]
+
+    Returns a new list; the input is not mutated.
+
+    Args:
+    ----
+        timings: Word timing dicts with ``word``, ``start_time``, ``end_time``.
+        min_word_sec: Rule 1 — minimum word duration. Words shorter than this
+            are extended to this length. Default 120 ms.
+        gap_merge_sec: Rule 2 — gaps between consecutive words shorter than
+            this are absorbed into the preceding word. Default 80 ms.
+        hold_last_sec: Rule 3 — extra hold time added to the last word of
+            each detected segment. Default 200 ms.
+        lead_sec: Rule 4 — how far ahead of the audio each word should
+            appear. Default 40 ms.
+        segment_gap_threshold_sec: Silence gap longer than this is treated as
+            a segment boundary (used by rule 3). Default 400 ms matches
+            ``word_timestamp_pause_threshold`` in subtitles.yaml.
+
+    """
+    if not timings:
+        return timings
+
+    out = [dict(t) for t in timings]
+
+    # Rule 4: lead — shift start earlier so the word appears just before
+    # it's spoken. Don't touch end_time; that still marks the audio offset.
+    for t in out:
+        t["start_time"] = max(0.0, t["start_time"] - lead_sec)
+
+    # Rule 2: merge short inter-word gaps into the preceding word.
+    # Walk forward so each adjustment only affects the immediate pair.
+    for i in range(1, len(out)):
+        gap = out[i]["start_time"] - out[i - 1]["end_time"]
+        if 0 <= gap < gap_merge_sec:
+            out[i - 1]["end_time"] = out[i]["start_time"]
+
+    # Rule 1: clamp minimum word duration. Extend end_time if needed.
+    for t in out:
+        dur = t["end_time"] - t["start_time"]
+        if dur < min_word_sec:
+            t["end_time"] = t["start_time"] + min_word_sec
+
+    # Rule 3: hold the last word of each segment past audio end.
+    # Detect segment boundaries via gaps exceeding the threshold.
+    for i in range(len(out)):
+        is_last_overall = i == len(out) - 1
+        is_segment_end = False
+        if not is_last_overall:
+            gap_to_next = out[i + 1]["start_time"] - out[i]["end_time"]
+            is_segment_end = gap_to_next >= segment_gap_threshold_sec
+        if is_last_overall or is_segment_end:
+            out[i]["end_time"] += hold_last_sec
+
+    count = len(out)
+    logger.debug(
+        "Smoothed %d word timings (lead=%.0fms, min=%.0fms, "
+        "gap=%.0fms, hold=%.0fms)",
+        count,
+        lead_sec * 1000,
+        min_word_sec * 1000,
+        gap_merge_sec * 1000,
+        hold_last_sec * 1000,
+    )
+    return out
+
+
+def smooth_whisper_result_dict(
+    result_w: dict[str, Any],
+    *,
+    min_word_sec: float = 0.12,
+    gap_merge_sec: float = 0.08,
+    hold_last_sec: float = 0.20,
+    lead_sec: float = 0.04,
+    segment_gap_threshold_sec: float = 0.40,
+) -> dict[str, Any]:
+    """Apply the same smoothing rules to the raw Whisper result dict.
+
+    Pycaps consumes the ``whisper_json`` format directly (segments → words →
+    start/end), so we need to smooth *that* dict in addition to the flat list.
+    Returns a deep-enough copy; the original dict is not mutated.
+
+    The word-level keys in Whisper's raw dict are ``"start"`` and ``"end"``
+    (not ``"start_time"``/``"end_time"`` as in the extracted flat list).
+    """
+    import copy
+
+    if not result_w or "segments" not in result_w:
+        return result_w
+
+    out = copy.deepcopy(result_w)
+
+    for segment in out["segments"]:
+        words = segment.get("words")
+        if not words:
+            continue
+
+        # Rule 4: lead
+        for w in words:
+            if "start" in w:
+                w["start"] = max(0.0, w["start"] - lead_sec)
+
+        # Rule 2: merge short gaps
+        for i in range(1, len(words)):
+            if "start" in words[i] and "end" in words[i - 1]:
+                gap = words[i]["start"] - words[i - 1]["end"]
+                if 0 <= gap < gap_merge_sec:
+                    words[i - 1]["end"] = words[i]["start"]
+
+        # Rule 1: clamp minimum duration
+        for w in words:
+            if "start" in w and "end" in w:
+                dur = w["end"] - w["start"]
+                if dur < min_word_sec:
+                    w["end"] = w["start"] + min_word_sec
+
+        # Rule 3: hold last word of this segment
+        if words and "end" in words[-1]:
+            words[-1]["end"] += hold_last_sec
+
+        # Update segment-level start/end to match smoothed word boundaries
+        first_start = next((w["start"] for w in words if "start" in w), None)
+        last_end = next((w["end"] for w in reversed(words) if "end" in w), None)
+        if first_start is not None:
+            segment["start"] = first_start
+        if last_end is not None:
+            segment["end"] = last_end
+
+    return out

--- a/src/video/subtitle_utils.py
+++ b/src/video/subtitle_utils.py
@@ -730,6 +730,9 @@ async def create_unified_subtitles(
                 script,
                 debug_mode,
                 transcript_out_path=whisper_transcript_target,
+                timing_smoothing_config=subtitle_settings.get(
+                    "timing_smoothing"
+                ),
             )
             if stt_timings:
                 logger.info(

--- a/src/video/subtitle_utils.py
+++ b/src/video/subtitle_utils.py
@@ -730,9 +730,7 @@ async def create_unified_subtitles(
                 script,
                 debug_mode,
                 transcript_out_path=whisper_transcript_target,
-                timing_smoothing_config=subtitle_settings.get(
-                    "timing_smoothing"
-                ),
+                timing_smoothing_config=subtitle_settings.get("timing_smoothing"),
             )
             if stt_timings:
                 logger.info(

--- a/tests/video/test_subtitle_timing_smoother.py
+++ b/tests/video/test_subtitle_timing_smoother.py
@@ -1,0 +1,275 @@
+"""Tests for subtitle timing post-processing (smoother).
+
+Covers the four best-practice rules applied to raw Whisper word timings:
+1. Minimum word duration clamp
+2. Short inter-word gap merge
+3. Last-word-of-segment hold
+4. Audio lead (pre-display offset)
+
+Also covers the parallel path that smooths the raw Whisper result dict
+for pycaps consumption.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from src.video.subtitle_timing_smoother import (
+    smooth_whisper_result_dict,
+    smooth_word_timings,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _word(text: str, start: float, end: float) -> dict:
+    return {"word": text, "start_time": start, "end_time": end}
+
+
+def _make_sentence() -> list[dict]:
+    """A short sentence with realistic Whisper timings."""
+    return [
+        _word("This", 0.50, 0.72),
+        _word("is", 0.74, 0.80),
+        _word("a", 0.82, 0.86),
+        _word("test", 0.88, 1.20),
+        _word("sentence", 1.22, 1.80),
+    ]
+
+
+def _make_two_segments() -> list[dict]:
+    """Two segments separated by a gap > 0.4s."""
+    return [
+        _word("First", 0.50, 0.90),
+        _word("part", 0.92, 1.30),
+        # gap of 0.6s — segment boundary
+        _word("Second", 1.90, 2.30),
+        _word("part", 2.32, 2.70),
+    ]
+
+
+def _make_whisper_dict(words_per_segment: list[list[dict]]) -> dict:
+    """Build a minimal Whisper result dict from word lists.
+
+    Word dicts here use Whisper's raw keys ("start"/"end"), not the
+    extracted flat-list keys ("start_time"/"end_time").
+    """
+    segments = []
+    for i, words in enumerate(words_per_segment):
+        seg_words = [
+            {"word": w["word"], "start": w["start"], "end": w["end"]} for w in words
+        ]
+        segments.append(
+            {
+                "id": i,
+                "start": words[0]["start"],
+                "end": words[-1]["end"],
+                "text": " ".join(w["word"] for w in words),
+                "words": seg_words,
+            }
+        )
+    return {"language": "en", "text": "test", "segments": segments}
+
+
+# ---------------------------------------------------------------------------
+# smooth_word_timings
+# ---------------------------------------------------------------------------
+
+
+class TestSmoothWordTimings:
+    """Tests for the flat-list smoother."""
+
+    def test_empty_input(self):
+        assert smooth_word_timings([]) == []
+
+    def test_single_word(self):
+        timings = [_word("Hello", 1.0, 1.5)]
+        result = smooth_word_timings(timings)
+        assert len(result) == 1
+        # Rule 4: lead shifts start earlier
+        assert result[0]["start_time"] == pytest.approx(0.96)
+        # Rule 3: hold adds to end (single word = last of segment)
+        assert result[0]["end_time"] == pytest.approx(1.70)
+
+    def test_does_not_mutate_input(self):
+        timings = [_word("Hello", 1.0, 1.5)]
+        original = copy.deepcopy(timings)
+        smooth_word_timings(timings)
+        assert timings == original
+
+    def test_lead_shifts_start_earlier(self):
+        timings = [_word("Word", 0.50, 1.00)]
+        result = smooth_word_timings(timings, lead_sec=0.10)
+        assert result[0]["start_time"] == pytest.approx(0.40)
+
+    def test_lead_clamps_to_zero(self):
+        timings = [_word("Word", 0.02, 0.50)]
+        result = smooth_word_timings(timings, lead_sec=0.10)
+        assert result[0]["start_time"] == 0.0
+
+    def test_min_word_duration_clamp(self):
+        # Word with 0.04s duration, shorter than default 0.12s
+        timings = [_word("a", 1.00, 1.04)]
+        result = smooth_word_timings(
+            timings, min_word_sec=0.12, lead_sec=0.0, hold_last_sec=0.0
+        )
+        assert result[0]["end_time"] == pytest.approx(1.12)
+
+    def test_gap_merge(self):
+        # Two words with a 0.05s gap (under default 0.08s threshold)
+        timings = [
+            _word("Hello", 1.00, 1.30),
+            _word("world", 1.35, 1.80),
+        ]
+        result = smooth_word_timings(
+            timings, gap_merge_sec=0.08, lead_sec=0.0, hold_last_sec=0.0
+        )
+        # Gap of 0.05s should be merged: first word's end → second word's start
+        # After lead (0.0), word1 end should extend to word2 start
+        assert result[0]["end_time"] == pytest.approx(result[1]["start_time"])
+
+    def test_gap_not_merged_when_large(self):
+        # Two words with a 0.20s gap (above 0.08s threshold)
+        timings = [
+            _word("Hello", 1.00, 1.30),
+            _word("world", 1.50, 1.80),
+        ]
+        result = smooth_word_timings(
+            timings, gap_merge_sec=0.08, lead_sec=0.0, hold_last_sec=0.0
+        )
+        # Gap is too large — don't merge
+        assert result[0]["end_time"] == pytest.approx(1.30)
+
+    def test_hold_last_word_of_segment(self):
+        timings = _make_two_segments()
+        result = smooth_word_timings(
+            timings,
+            hold_last_sec=0.20,
+            lead_sec=0.0,
+            segment_gap_threshold_sec=0.40,
+        )
+        # "part" at index 1 is last word of first segment
+        assert result[1]["end_time"] == pytest.approx(1.30 + 0.20)
+        # "part" at index 3 is last word overall
+        assert result[3]["end_time"] == pytest.approx(2.70 + 0.20)
+
+    def test_hold_not_applied_to_mid_segment_words(self):
+        timings = _make_two_segments()
+        result = smooth_word_timings(
+            timings,
+            hold_last_sec=0.20,
+            lead_sec=0.0,
+            gap_merge_sec=0.0,  # disable gap merge to isolate hold rule
+            segment_gap_threshold_sec=0.40,
+        )
+        # "First" at index 0 is NOT the last word of a segment — no hold added
+        assert result[0]["end_time"] == pytest.approx(0.90)
+
+    def test_all_rules_combined(self):
+        """Smoke test with all rules active on a realistic sentence."""
+        timings = _make_sentence()
+        result = smooth_word_timings(timings)
+        assert len(result) == len(timings)
+        # All start times should be non-negative
+        for t in result:
+            assert t["start_time"] >= 0.0
+        # All words should have at least min_word_sec duration
+        for t in result:
+            dur = t["end_time"] - t["start_time"]
+            assert dur >= 0.12 - 1e-9  # float tolerance
+
+    def test_custom_params(self):
+        timings = [_word("test", 2.00, 2.50)]
+        result = smooth_word_timings(
+            timings,
+            min_word_sec=0.20,
+            gap_merge_sec=0.10,
+            hold_last_sec=0.30,
+            lead_sec=0.05,
+        )
+        # lead: 2.00 - 0.05 = 1.95
+        assert result[0]["start_time"] == pytest.approx(1.95)
+        # hold: 2.50 + 0.30 = 2.80
+        assert result[0]["end_time"] == pytest.approx(2.80)
+
+
+# ---------------------------------------------------------------------------
+# smooth_whisper_result_dict
+# ---------------------------------------------------------------------------
+
+
+class TestSmoothWhisperResultDict:
+    """Tests for the raw Whisper dict smoother (pycaps path)."""
+
+    def test_empty_or_missing_segments(self):
+        assert smooth_whisper_result_dict({}) == {}
+        assert smooth_whisper_result_dict({"text": "hi"}) == {"text": "hi"}
+
+    def test_does_not_mutate_input(self):
+        raw_words = [
+            {"word": "Hello", "start": 0.50, "end": 0.90},
+            {"word": "world", "start": 0.92, "end": 1.30},
+        ]
+        original = _make_whisper_dict([raw_words])
+        frozen = copy.deepcopy(original)
+        smooth_whisper_result_dict(original)
+        assert original == frozen
+
+    def test_lead_applied(self):
+        raw_words = [
+            {"word": "Hello", "start": 0.50, "end": 0.90},
+        ]
+        result = smooth_whisper_result_dict(
+            _make_whisper_dict([raw_words]), lead_sec=0.10
+        )
+        words = result["segments"][0]["words"]
+        assert words[0]["start"] == pytest.approx(0.40)
+
+    def test_segment_boundaries_updated(self):
+        raw_words = [
+            {"word": "Hello", "start": 0.50, "end": 0.90},
+            {"word": "world", "start": 0.92, "end": 1.30},
+        ]
+        result = smooth_whisper_result_dict(
+            _make_whisper_dict([raw_words]),
+            lead_sec=0.04,
+            hold_last_sec=0.20,
+        )
+        seg = result["segments"][0]
+        # Segment start should match first word's smoothed start
+        assert seg["start"] == pytest.approx(seg["words"][0]["start"])
+        # Segment end should match last word's smoothed end (with hold)
+        assert seg["end"] == pytest.approx(seg["words"][-1]["end"])
+
+    def test_multiple_segments(self):
+        seg1_words = [
+            {"word": "First", "start": 0.50, "end": 0.90},
+        ]
+        seg2_words = [
+            {"word": "Second", "start": 2.00, "end": 2.50},
+        ]
+        result = smooth_whisper_result_dict(
+            _make_whisper_dict([seg1_words, seg2_words]),
+            hold_last_sec=0.20,
+            lead_sec=0.0,
+        )
+        # Each segment's last word gets the hold
+        assert result["segments"][0]["words"][0]["end"] == pytest.approx(1.10)
+        assert result["segments"][1]["words"][0]["end"] == pytest.approx(2.70)
+
+    def test_min_word_duration_in_dict(self):
+        raw_words = [
+            {"word": "a", "start": 1.00, "end": 1.02},  # 20ms — too short
+        ]
+        result = smooth_whisper_result_dict(
+            _make_whisper_dict([raw_words]),
+            min_word_sec=0.12,
+            lead_sec=0.0,
+            hold_last_sec=0.0,
+        )
+        w = result["segments"][0]["words"][0]
+        assert w["end"] == pytest.approx(1.12)

--- a/tests/video/test_subtitle_timing_smoother.py
+++ b/tests/video/test_subtitle_timing_smoother.py
@@ -273,3 +273,33 @@ class TestSmoothWhisperResultDict:
         )
         w = result["segments"][0]["words"][0]
         assert w["end"] == pytest.approx(1.12)
+
+    def test_segment_with_no_words_skipped(self):
+        """Segments without a 'words' list are left untouched."""
+        raw = {
+            "language": "en",
+            "text": "test",
+            "segments": [
+                {"id": 0, "start": 0.0, "end": 1.0, "text": "Hello"},
+            ],
+        }
+        result = smooth_whisper_result_dict(raw)
+        # Segment is preserved, no crash
+        assert len(result["segments"]) == 1
+        assert "words" not in result["segments"][0]
+
+    def test_gap_merge_in_dict(self):
+        """Short inter-word gaps inside a segment are merged."""
+        raw_words = [
+            {"word": "Hello", "start": 1.00, "end": 1.30},
+            {"word": "world", "start": 1.35, "end": 1.80},  # 50ms gap
+        ]
+        result = smooth_whisper_result_dict(
+            _make_whisper_dict([raw_words]),
+            gap_merge_sec=0.08,
+            lead_sec=0.0,
+            hold_last_sec=0.0,
+        )
+        words = result["segments"][0]["words"]
+        # Gap of 50ms < 80ms threshold → merged
+        assert words[0]["end"] == pytest.approx(words[1]["start"])


### PR DESCRIPTION
# Pull Request

## Summary

Raw Whisper word timestamps suffer from coarse rounding, producing flickering and uneven segment durations in karaoke-style captions. This adds a timing post-processing step that applies four best-practice smoothing rules after STT and before either subtitle engine consumes the timings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- New module `src/video/subtitle_timing_smoother.py` with two public functions: `smooth_word_timings` (flat list for FFmpeg) and `smooth_whisper_result_dict` (raw Whisper dict for pycaps)
- Wired into `generate_subtitles_with_whisper` in `stt_functions.py` so both engines get smoothed timings from one call site
- YAML config in `config/subtitles.yaml` under `timing_smoothing` section, passed through as a nested dict
- Config passthrough from `create_unified_subtitles` to the smoother via kwargs

## The four rules

1. Clamp minimum word duration to 120ms (prevents imperceptible flashes)
2. Merge inter-word gaps under 80ms into the preceding word (eliminates micro-flicker)
3. Hold last word of each segment +200ms past audio end (caption lingers after speech)
4. Lead audio by 40ms so the word appears just before it's spoken

## Testing

- [x] Existing tests pass
- [x] 20 unit tests covering each rule in isolation, combined rules, edge cases (empty input, single word, segment boundaries), custom params, input immutability, and the Whisper dict path
- [x] 100% coverage on `subtitle_timing_smoother.py`
- [x] mypy clean (269 files, 0 errors)
- [x] ruff clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced

## Deployment Notes

Enabled by default. Disable via `timing_smoothing.enabled: false` in subtitles.yaml or per-profile override. No new env vars or dependencies.

## Module/Batch Alignment Rule

No new env vars needed. The smoother runs inside `generate_subtitles_with_whisper` which is called by both `cli.py` and `global_batch.py` through `create_unified_subtitles`. No secrets dict changes required.