### PR TITLE
Fix safe zone config passthrough in subtitle generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `UnifiedSubtitleGenerator` now reads safe zone from config instead of hardcoded `PlatformSafeZone()` defaults
+- Profile-level `subtitle_safe_zone_*` overrides are now wired through to the subtitle generator
+
 ## [0.37.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.1] - 2026-04-14
+
 ### Fixed
 - `UnifiedSubtitleGenerator` now reads safe zone from config instead of hardcoded `PlatformSafeZone()` defaults
 - Profile-level `subtitle_safe_zone_*` overrides are now wired through to the subtitle generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `UnifiedSubtitleGenerator` now reads safe zone from config instead of hardcoded `PlatformSafeZone()` defaults
 - Profile-level `subtitle_safe_zone_*` overrides are now wired through to the subtitle generator
+- Pycaps `max_width_ratio` is dynamically clamped to the platform safe zone at render time so captions stay inside TikTok/Shorts/Reels UI overlay boundaries regardless of template or font
 
 ## [0.37.0] - 2026-04-14
 

--- a/config/subtitles.yaml
+++ b/config/subtitles.yaml
@@ -67,9 +67,12 @@ subtitle_settings:
     renderer: "css"
 
     # Max caption width as a fraction of frame width.
-    # 0.80 matches the best-practice recipe (80% of frame, ~864px on 1080).
-    # Was 0.85 — slightly over the recommended safe zone.
-    max_width_ratio: 0.80
+    # 0.65 keeps captions inside the TikTok safe zone (right boundary at
+    # 0.778) even with uppercase bold fonts. Was 0.80 which looked fine
+    # for the FFmpeg path but spanned edge-to-edge on pycaps templates
+    # because CSS font scaling + uppercase inflate the rendered width
+    # beyond what max_width_ratio alone constrains.
+    max_width_ratio: 0.65
 
     # Max lines per caption segment. 2 lines is the universal best practice
     # for short-form — 3+ becomes a wall of text.

--- a/config/subtitles.yaml
+++ b/config/subtitles.yaml
@@ -66,13 +66,12 @@ subtitle_settings:
     # pictex = browserless Skia. Lighter install, limited CSS features.
     renderer: "css"
 
-    # Max caption width as a fraction of frame width.
-    # 0.65 keeps captions inside the TikTok safe zone (right boundary at
-    # 0.778) even with uppercase bold fonts. Was 0.80 which looked fine
-    # for the FFmpeg path but spanned edge-to-edge on pycaps templates
-    # because CSS font scaling + uppercase inflate the rendered width
-    # beyond what max_width_ratio alone constrains.
-    max_width_ratio: 0.65
+    # Max caption width as a fraction of frame width. This is the
+    # user-facing knob; the actual value passed to pycaps is clamped
+    # to the platform safe zone at render time so captions never
+    # extend into TikTok/Shorts/Reels UI overlay zones regardless
+    # of what's set here.
+    max_width_ratio: 0.80
 
     # Max lines per caption segment. 2 lines is the universal best practice
     # for short-form — 3+ becomes a wall of text.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -173,7 +173,8 @@ High-level requirements for ContentEngineAI.
 - **Margin** from anchor edge (default 4%)
 - **Horizontal alignment**: left, center (default), right
 - Content-aware positioning relative to actual media bounds
-- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. Cross-platform union: top 220px, bottom 480px, left/right 90px on 1080x1920.
+- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. Cross-platform union: top 220px, bottom 480px, left/right 90px on 1080x1920. Configurable globally in YAML and per-profile via `subtitle_safe_zone_*` overrides.
+- Both engines enforce the safe zone: FFmpeg clamps subtitle width to safe zone boundaries, pycaps dynamically clamps `max_width_ratio` so centered text never extends past the right-side boundary (TikTok buttons). The clamping is automatic — no manual tuning needed per template.
 - Pycaps default position: bottom of safe zone (~75% of frame). Template's own alignment preserved unless explicitly overridden.
 
 **Text formatting (best-practice aligned):**

--- a/docs/subtitle-config-cleanup.md
+++ b/docs/subtitle-config-cleanup.md
@@ -21,13 +21,13 @@ This document exists to:
 
 ## TL;DR
 
-One bug fixed, two remaining. Four high-value refactors, ~20 dead fields.
+All bugs fixed. Four high-value refactors, ~20 dead fields.
 
 | # | Work item | Kind | Status | Effort |
 |---|---|---|---|---|
 | 1 | ~~Fix duration key namespace + width fraction passthrough~~ | ~~Bug~~ | **FIXED** (commit `c385df1`) | ~~30 min~~ |
-| 2 | `UnifiedSubtitleGenerator` constructs fresh `PlatformSafeZone()` instead of reading config | **Bug** | Open | 15 min |
-| 3 | Wire profile `subtitle_safe_zone_*` overrides into `_collect_overrides` field map | **Bug** | Open | 15 min |
+| 2 | ~~`UnifiedSubtitleGenerator` constructs fresh `PlatformSafeZone()` instead of reading config~~ | ~~Bug~~ | **FIXED** (PR #65) | ~~15 min~~ |
+| 3 | ~~Wire profile `subtitle_safe_zone_*` overrides into `_collect_overrides` field map~~ | ~~Bug~~ | **FIXED** (PR #65) | ~~15 min~~ |
 | 4 | Collapse `MergedSubtitleSettings` + `UnifiedSubtitleConfig` into one typed model | **Refactor** | Open | 1-2 days |
 | 5 | Nest `two_part_subtitles` as a typed sub-model instead of 14 flat fields | **Refactor** | Open | 0.5 day |
 | 6 | Move `style_presets` into the Pydantic model, delete the inline YAML re-read in `get_style_config()` | **Refactor** | Open | 0.5 day |
@@ -36,7 +36,7 @@ One bug fixed, two remaining. Four high-value refactors, ~20 dead fields.
 | 9 | Remove the "Legacy Compatibility Settings" block in `subtitle_settings` | **Cleanup** | Open (gated on #6) | 1 hour |
 | 10 | Rename duplicate/confusing keys to canonical names | **Cleanup** | Open (gated on #4) | 1 hour |
 
-Remaining effort: roughly 4 days if everything open is done.
+Remaining effort: roughly 3.5 days if everything open is done.
 
 ---
 
@@ -168,7 +168,9 @@ Three sub-issues were resolved together:
 **Verification**: all 9 profiles confirmed passing best-practice checks after
 the fix.
 
-### 3.2 `UnifiedSubtitleGenerator` constructs its own safe zone
+### 3.2 `UnifiedSubtitleGenerator` constructs its own safe zone — FIXED
+
+**Status**: fixed in PR #65 on `bugfix/safe-zone-config-passthrough`.
 
 **Where**: `src/video/unified_subtitle_generator.py:565-569`
 
@@ -187,7 +189,9 @@ alongside `config`, or have it read from a shared singleton. The
 subtitle_builder already has a `_get_safe_zone()` helper that does the
 right thing — extract it and reuse.
 
-### 3.3 Profile-level safe zone overrides are dead
+### 3.3 Profile-level safe zone overrides are dead — FIXED
+
+**Status**: fixed in PR #65 on `bugfix/safe-zone-config-passthrough`.
 
 **Where**: `src/video/config/visual_models.py:312-321`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.37.0"
+version = "0.37.1"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/video/config/core_models.py
+++ b/src/video/config/core_models.py
@@ -761,6 +761,20 @@ class VideoConfig(BaseModel):
         if profile.subtitle_positioning:
             subtitle_data.update(profile.subtitle_positioning)
 
+        # Apply per-profile safe zone overrides (subtitle_safe_zone_* fields).
+        # Build a PlatformSafeZone with profile values overriding the global.
+        sz_overrides: dict[str, float] = {}
+        for attr in ("min_x", "max_x", "min_y", "max_y"):
+            val = getattr(profile, f"subtitle_safe_zone_{attr}", None)
+            if val is not None:
+                sz_overrides[attr] = val
+        if sz_overrides:
+            base_sz = subtitle_data.get("safe_zone")
+            if isinstance(base_sz, PlatformSafeZone):
+                subtitle_data["safe_zone"] = base_sz.model_copy(update=sz_overrides)
+            else:
+                subtitle_data["safe_zone"] = PlatformSafeZone(**sz_overrides)
+
         # Engine + nested pycaps profile overrides. Flat VideoProfile fields
         # (pycaps_template, pycaps_renderer, ...) fold into the nested
         # subtitle_data["pycaps"] dict so Pydantic can build PycapsSettings.
@@ -940,6 +954,10 @@ class VideoConfig(BaseModel):
             # Pycaps engine selector + nested sub-settings (YAML layer)
             "subtitle_engine": ss.get("subtitle_engine", "ffmpeg"),
             "pycaps": ss.get("pycaps"),
+            # Safe zone from text_rendering config (global YAML layer)
+            "safe_zone": (
+                self.text_rendering.safe_zone if self.text_rendering else None
+            ),
         }
 
     def get_product_paths(self, product_id: str, profile_name: str) -> dict[str, Path]:

--- a/src/video/config/subtitle_models.py
+++ b/src/video/config/subtitle_models.py
@@ -148,14 +148,15 @@ class PycapsSettings(BaseModel):
         ),
     )
     max_width_ratio: float = Field(
-        0.80,
+        0.65,
         ge=0.0,
         le=1.0,
         description=(
             "Maximum line width as a fraction of frame width, handed to pycaps "
-            "SubtitleLayoutOptions. 0.80 matches the best-practice recipe in "
-            "docs/subtitle-best-practices.md — leaves ~90px margin on each "
-            "side of a 1080-wide frame, inside all three platform safe zones."
+            "SubtitleLayoutOptions. 0.65 keeps captions inside the TikTok safe "
+            "zone even with uppercase bold fonts. The CSS renderer scales fonts "
+            "relative to video width, so 0.80 (the FFmpeg best-practice target) "
+            "produces edge-to-edge captions on pycaps templates."
         ),
     )
     max_number_of_lines: int = Field(

--- a/src/video/config/subtitle_models.py
+++ b/src/video/config/subtitle_models.py
@@ -148,15 +148,14 @@ class PycapsSettings(BaseModel):
         ),
     )
     max_width_ratio: float = Field(
-        0.65,
+        0.80,
         ge=0.0,
         le=1.0,
         description=(
             "Maximum line width as a fraction of frame width, handed to pycaps "
-            "SubtitleLayoutOptions. 0.65 keeps captions inside the TikTok safe "
-            "zone even with uppercase bold fonts. The CSS renderer scales fonts "
-            "relative to video width, so 0.80 (the FFmpeg best-practice target) "
-            "produces edge-to-edge captions on pycaps templates."
+            "SubtitleLayoutOptions. The actual value is clamped at render time "
+            "to the platform safe zone so captions never extend into UI "
+            "overlay zones regardless of what's set here."
         ),
     )
     max_number_of_lines: int = Field(

--- a/src/video/producer/steps.py
+++ b/src/video/producer/steps.py
@@ -1172,6 +1172,11 @@ async def step_burn_pycaps_subtitles(ctx: PipelineContext):
             PycapsUnavailableError,
         )
 
+        # Extract safe zone from subtitle settings (flows via extra="allow"
+        # from _build_subtitle_base). Clamps pycaps max_width_ratio so
+        # captions stay inside platform UI overlay boundaries.
+        safe_zone = getattr(subtitle_settings, "safe_zone", None)
+
         renderer = PycapsRenderer()
         try:
             result = await asyncio.to_thread(
@@ -1182,6 +1187,7 @@ async def step_burn_pycaps_subtitles(ctx: PipelineContext):
                 product_id,
                 visual_bounds,
                 pycaps_settings,
+                safe_zone=safe_zone,
             )
         except PycapsUnavailableError as e:
             msg = (

--- a/src/video/pycaps_engine/renderer.py
+++ b/src/video/pycaps_engine/renderer.py
@@ -97,10 +97,30 @@ def select_template_for_product(
     return pool[index]
 
 
+def _safe_zone_max_width(safe_zone: Any) -> float | None:
+    """Compute the maximum width ratio that keeps centered text inside the safe zone.
+
+    For center-aligned text the constraint is:
+    ``max_width = 2 * min(0.5 - min_x, max_x - 0.5)``
+
+    Returns None when no safe zone is provided or when the safe zone is
+    wider than the frame (no clamping needed).
+    """
+    if safe_zone is None:
+        return None
+    min_x = getattr(safe_zone, "min_x", 0.0)
+    max_x = getattr(safe_zone, "max_x", 1.0)
+    limit = 2.0 * min(0.5 - min_x, max_x - 0.5)
+    if limit >= 1.0:
+        return None
+    return max(0.1, limit)  # floor at 10% to avoid degenerate layouts
+
+
 def merge_layout_with_template(
     template_layout: Any,
     settings: PycapsSettings,
     bounds: VisualBounds | None = None,
+    safe_zone: Any = None,
 ) -> Any:
     """Merge our config values into the template's own layout.
 
@@ -114,6 +134,8 @@ def merge_layout_with_template(
 
     - ``max_width_ratio`` and ``max_number_of_lines`` always override
       (these are safe, template-agnostic layout constraints).
+    - ``max_width_ratio`` is clamped to the platform safe zone when provided
+      so captions never extend into TikTok/Shorts/Reels UI overlay zones.
     - ``vertical_align`` is only overridden when the user sets an explicit
       ``vertical_align_offset``. Otherwise the template's own alignment
       (center, bottom, etc.) is preserved.
@@ -123,9 +145,20 @@ def merge_layout_with_template(
         VerticalAlignmentType,
     )
 
+    # Clamp max_width_ratio to safe zone boundaries.
+    width_ratio = settings.max_width_ratio
+    sz_limit = _safe_zone_max_width(safe_zone)
+    if sz_limit is not None and width_ratio > sz_limit:
+        logger.debug(
+            "Clamping max_width_ratio from %.2f to %.2f (safe zone)",
+            width_ratio,
+            sz_limit,
+        )
+        width_ratio = sz_limit
+
     # Start from the template's layout and override width/lines.
     updates: dict[str, Any] = {
-        "max_width_ratio": settings.max_width_ratio,
+        "max_width_ratio": width_ratio,
         "max_number_of_lines": settings.max_number_of_lines,
     }
 
@@ -207,6 +240,7 @@ class PycapsRenderer:
         product_id: str,
         visual_bounds: VisualBounds | None,
         settings: PycapsSettings,
+        safe_zone: Any = None,
     ) -> PycapsRenderResult:
         """Burn pycaps captions onto ``input_video`` and write ``output_video``.
 
@@ -223,6 +257,8 @@ class PycapsRenderer:
                 the layout offset is computed to place captions below the
                 content. When None, pycaps defaults apply.
             settings: Typed pycaps settings from the merged profile.
+            safe_zone: Optional ``PlatformSafeZone`` for clamping caption
+                width to avoid platform UI overlays.
 
         Returns:
         -------
@@ -246,6 +282,7 @@ class PycapsRenderer:
                 template_name=template_used,
                 visual_bounds=visual_bounds,
                 settings=settings,
+                safe_zone=safe_zone,
             )
         except ImportError as e:
             raise PycapsUnavailableError(
@@ -330,6 +367,7 @@ class PycapsRenderer:
         template_name: str,
         visual_bounds: VisualBounds | None,
         settings: PycapsSettings,
+        safe_zone: Any = None,
     ) -> tuple[Any, Any | None]:
         """Construct the ``CapsPipelineBuilder`` and apply layout + renderer.
 
@@ -353,7 +391,7 @@ class PycapsRenderer:
         # the user explicitly set vertical_align_offset.
         template_layout = builder._caps_pipeline._layout_options
         merged_layout = merge_layout_with_template(
-            template_layout, settings, visual_bounds
+            template_layout, settings, visual_bounds, safe_zone=safe_zone
         )
         builder.with_layout_options(merged_layout)
 

--- a/src/video/subtitle_positioning.py
+++ b/src/video/subtitle_positioning.py
@@ -133,6 +133,13 @@ class UnifiedSubtitleConfig(BaseModel):
         None, description="Override color pair selection"
     )
 
+    # Platform safe zone (read from config.text_rendering.safe_zone, with
+    # optional per-profile overrides via subtitle_safe_zone_* fields)
+    safe_zone: PlatformSafeZone = Field(
+        default_factory=PlatformSafeZone,
+        description="Platform UI overlay avoidance boundaries",
+    )
+
     # Advanced positioning (optional fine-tuning)
     custom_position: Position | None = Field(
         None, description="Custom position override (x,y as 0.0-1.0 fractions)"
@@ -470,6 +477,15 @@ def create_unified_config_from_settings(
         logger.warning(f"Invalid style_preset '{preset_str}', using 'modern'")
         style_preset = StylePreset.MODERN
 
+    # Build safe zone from settings if present, otherwise use defaults
+    safe_zone_data = settings.get("safe_zone")
+    if isinstance(safe_zone_data, dict):
+        safe_zone = PlatformSafeZone(**safe_zone_data)
+    elif isinstance(safe_zone_data, PlatformSafeZone):
+        safe_zone = safe_zone_data
+    else:
+        safe_zone = PlatformSafeZone()
+
     return UnifiedSubtitleConfig(
         anchor=anchor,
         content_aware=settings.get("content_aware", True),
@@ -492,4 +508,5 @@ def create_unified_config_from_settings(
         selected_color_pair=settings.get("selected_color_pair"),
         custom_position=settings.get("custom_position"),
         horizontal_alignment=settings.get("horizontal_alignment", "center"),
+        safe_zone=safe_zone,
     )

--- a/src/video/unified_subtitle_generator.py
+++ b/src/video/unified_subtitle_generator.py
@@ -561,10 +561,8 @@ class UnifiedSubtitleGenerator:
                     self.frame_size[0] * self.config.max_subtitle_width_fraction
                 )
 
-                # Cap against safe zone width
-                from src.video.config.core_models import PlatformSafeZone
-
-                sz = PlatformSafeZone()
+                # Cap against safe zone width (reads from config, not hardcoded)
+                sz = self.config.safe_zone
                 safe_zone_width = int(self.frame_size[0] * (sz.max_x - sz.min_x))
                 max_width = min(max_width, safe_zone_width)
 


### PR DESCRIPTION
# Pull Request

## Summary

Platform safe zone config was silently ignored by both subtitle engines. This wires safe zone values from YAML through the full config pipeline and adds dynamic width clamping for pycaps.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

**Bug #2 — FFmpeg path**: `UnifiedSubtitleGenerator` now reads `self.config.safe_zone` instead of constructing a fresh `PlatformSafeZone()` with hardcoded defaults. YAML overrides to `text_rendering.safe_zone` now take effect.

**Bug #3 — Profile overrides**: `subtitle_safe_zone_*` fields on `VideoProfile` are now wired into `_collect_overrides`. They merge on top of the global safe zone via `model_copy(update=...)`.

**Pycaps dynamic clamping**: `merge_layout_with_template` now clamps `max_width_ratio` to the safe zone at render time using `2 * min(0.5 - min_x, max_x - 0.5)`. With the default safe zone (TikTok right boundary at 0.778), this clamps to 0.556 regardless of template or font. The user's `max_width_ratio` is an upper bound that the safe zone can only tighten.

**Config flow**: `_build_subtitle_base` passes `text_rendering.safe_zone` into the subtitle data dict. The pycaps step extracts it via `getattr(subtitle_settings, "safe_zone", None)` and threads it through to the renderer. `create_unified_config_from_settings` handles both dict and `PlatformSafeZone` object forms.

## Testing

- [x] All 2053 existing tests pass (no regressions)
- [x] mypy clean (269 files, 0 errors)
- [x] ruff clean

## Deployment Notes

No behavioral change for users who haven't overridden safe zone values — the defaults match what was previously hardcoded. Pycaps captions will be narrower (clamped to ~56% of frame width) which fixes the edge-to-edge rendering visible with bold uppercase templates like word-focus.