### PR TITLE
Collapse MergedSubtitleSettings + UnifiedSubtitleConfig into one model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ cache/
 
 # Claude Code config (contains credentials)
 .claude.json
+
+# Claude Code per-user / runtime state. .claude/settings.json (team config)
+# should be committed if/when it exists; the entries below are personal or
+# runtime-only and never go in git.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking**: Unified the historical `MergedSubtitleSettings` (config side, `extra="allow"`) and `UnifiedSubtitleConfig` (runtime side) into a single strict `SubtitleSettings` model. The dict round-trip translator that used to bridge them is gone, eliminating the silent-drop class of bugs (e.g. profile overrides whose value got lost at the model→dict boundary). Canonical field names land here too: `max_duration` / `min_duration` replace `max_subtitle_duration` / `min_subtitle_duration`.
+- **Breaking**: Profile overrides on `VideoProfile` use a single nested `subtitle_settings: PartialSubtitleSettings | None` block. The 30+ flat `subtitle_*` / `pycaps_*` / `two_part_subtitles_*` fields are gone. A migration shim accepts the legacy shape with a `DeprecationWarning` for one release.
+- `SubtitleSettings` is strict (`extra="forbid"`); YAML typos throw `ValidationError` at load time instead of being silently dropped at runtime. `SubtitleSettings.from_legacy_dict()` translates the historical names and drops underscore-prefixed runtime side-channel keys.
+- `PlatformSafeZone`, `PositionAnchor`, `StylePreset`, and `Position` moved into `src/video/config/subtitle_models.py`. Old import paths still work via re-exports.
+
+### Removed
+- `MergedSubtitleSettings`, `UnifiedSubtitleConfig`, and `create_unified_config_from_settings` are gone. Callers now construct `SubtitleSettings` directly or via `from_legacy_dict`.
+- The `_collect_overrides` field_map for subtitle settings (~20 entries) and the per-profile pycaps/safe_zone/two_part folding code in `get_profile_merged_settings`. Replaced by `partial.merge_into(base)` in three lines.
+
+### Added
+- `PartialSubtitleSettings.merge_into(base)` deep-merges non-None overrides; nested models (`pycaps`, `two_part_subtitles`, `safe_zone`) merge per-field rather than being replaced wholesale.
+
 ## [0.41.0] - 2026-04-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-04-18
+
 ### Changed
 - **Breaking**: Unified the historical `MergedSubtitleSettings` (config side, `extra="allow"`) and `UnifiedSubtitleConfig` (runtime side) into a single strict `SubtitleSettings` model. The dict round-trip translator that used to bridge them is gone, eliminating the silent-drop class of bugs (e.g. profile overrides whose value got lost at the model→dict boundary). Canonical field names land here too: `max_duration` / `min_duration` replace `max_subtitle_duration` / `min_subtitle_duration`.
 - **Breaking**: Profile overrides on `VideoProfile` use a single nested `subtitle_settings: PartialSubtitleSettings | None` block. The 30+ flat `subtitle_*` / `pycaps_*` / `two_part_subtitles_*` fields are gone. A migration shim accepts the legacy shape with a `DeprecationWarning` for one release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ poetry run python tools/performance_report.py --report-type detailed --format cs
 ### Video Module Notes
 
 - **Profile settings**: `get_profile_merged_settings()` returns typed `MergedProfileSettings` (not dicts). Access via `.video_settings.field` and `.subtitle_settings.field`. Use `.model_dump()` when downstream functions need dicts.
+- **Subtitle config model**: `SubtitleSettings` (in `src/video/config/subtitle_models.py`) is the single source of truth — both the config-layer merge output and runtime generator input. Strict (`extra="forbid"`); YAML typos throw at load. `from_legacy_dict()` translates renames (`max_subtitle_duration` → `max_duration`, `min_subtitle_duration` → `min_duration`) and drops underscore-prefixed runtime side-channel keys.
+- **Subtitle profile overrides**: `VideoProfile.subtitle_settings: PartialSubtitleSettings | None` is a single nested block; `partial.merge_into(base)` deep-merges (nested sub-models like `pycaps`, `two_part_subtitles`, `safe_zone` merge per-field). The `@model_validator(mode="before")` shim on `VideoProfile` migrates legacy flat keys (`subtitle_anchor`, `pycaps_template`, `two_part_subtitles`, ...) to the nested block at load with a `DeprecationWarning` for one release.
 - **Video centering**: Use `video_vertical_align: center` in profile config. Setting `video_top_position_percent: 0.0` puts video at top, not center. The `center` value triggers FFmpeg's `(oh-ih)/2` pad expression.
 - **Subtitle positioning**: For centered images with mixed aspect ratios (landscape + portrait), use AVERAGE `video_top` across all images to balance positioning
 - **Visual bounds**: Calculated from actual image dimensions, not frame dimensions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1526,8 +1526,9 @@ video_profiles:
     # Profile-Specific Image Settings
     image_width_percent: 0.85         # 85% frame width for product focus
 
-    # Profile-Specific Subtitle Settings
-    subtitle_randomize_effects: true  # Enable effect randomization
+    # Profile-Specific Subtitle Settings (nested override block)
+    subtitle_settings:
+      randomize_effects: true         # Enable effect randomization
 
   slideshow_images2:
     description: "Alternative slideshow with different styling"
@@ -1541,50 +1542,60 @@ video_profiles:
     image_width_percent: 0.80         # 80% frame width
     image_top_position_percent: 0.15  # Position 15% from top
 
-    # Subtitle positioning
-    subtitle_anchor: "below_content"  # Position below images
-    subtitle_margin: 0.08             # 8% gap below content
-    subtitle_content_aware: true      # Dynamic positioning
-    subtitle_horizontal_alignment: "center"
-
-    # Subtitle styling
-    subtitle_style_preset: "minimal"  # Clean minimal style
-    subtitle_font_size_scale: 0.9     # 10% smaller font
-    subtitle_randomize_fonts: true
-    subtitle_randomize_colors: true
-    subtitle_randomize_effects: false
-
-    # Text formatting
-    subtitle_max_line_length: 28
-    subtitle_max_words_per_line: 3
-    subtitle_max_subtitle_width_fraction: 0.85
-    subtitle_max_duration: 4.0
-    subtitle_min_duration: 0.5
+    # Subtitle overrides — single nested block, only fields that differ from
+    # the global subtitle_settings need to be set. Nested sub-blocks (pycaps,
+    # two_part_subtitles, safe_zone) deep-merge per-field.
+    subtitle_settings:
+      anchor: "below_content"
+      margin: 0.08
+      content_aware: true
+      horizontal_alignment: "center"
+      style_preset: "minimal"
+      font_size_scale: 0.9
+      randomize_fonts: true
+      randomize_colors: true
+      randomize_effects: false
+      max_line_length: 28
+      max_words_per_line: 3
+      max_subtitle_width_fraction: 0.85
+      max_duration: 2.5
+      min_duration: 0.6
 ```
 
 **Available Per-Profile Overrides:**
 
 ```yaml
-# Image Settings (all optional)
+# Image Settings (all optional, top-level on the profile)
 image_width_percent: 0.85            # Override global image width
 image_top_position_percent: 0.15     # Override global image position
 preserve_aspect_ratio: true          # Override aspect ratio setting
 
-# Subtitle Settings (all optional)
-subtitle_anchor: "below_content"     # Override positioning anchor
-subtitle_margin: 0.08                # Override margin from anchor
-subtitle_content_aware: true         # Override content-aware positioning
-subtitle_style_preset: "modern"     # Override style preset (minimal, modern, bold, animated, random)
-subtitle_font_size_scale: 1.1        # Override font size scaling
-subtitle_max_line_length: 35         # Override line length limit
-subtitle_max_words_per_line: 3       # Override max words per line
-subtitle_max_subtitle_width_fraction: 0.85  # Override max subtitle width
-subtitle_max_duration: 4.5           # Override max subtitle duration
-subtitle_min_duration: 0.4           # Override min subtitle duration
-subtitle_horizontal_alignment: "center"
-subtitle_randomize_fonts: false      # Override font randomization
-subtitle_randomize_colors: false     # Override color randomization
-subtitle_randomize_effects: false    # Override effect randomization
+# Subtitle Settings — single nested block. Any field on the global
+# subtitle_settings can be overridden here; unset fields inherit from global.
+subtitle_settings:
+  anchor: "below_content"            # top, center, bottom, above_content, below_content
+  margin: 0.08                       # Margin as fraction of frame height (0.0-0.5)
+  content_aware: true
+  horizontal_alignment: "center"     # left, center, right
+  style_preset: "modern"             # minimal, modern, bold, animated, random
+  font_size_scale: 1.1               # 0.5-2.0
+  max_line_length: 35
+  max_words_per_line: 3
+  max_subtitle_width_fraction: 0.85
+  max_duration: 2.5                  # Canonical name (was max_subtitle_duration)
+  min_duration: 0.6                  # Canonical name (was min_subtitle_duration)
+  randomize_fonts: false
+  randomize_colors: false
+  randomize_effects: false
+  pycaps:                            # Nested pycaps overrides (deep-merged)
+    template_name: "hype"
+    renderer: "css"
+  two_part_subtitles:                # Nested two-part overrides (deep-merged)
+    enabled: true
+    upper_line:
+      style_preset: "minimal"
+  safe_zone:                         # Nested safe-zone overrides (deep-merged)
+    max_y: 0.65                      # Tighter bottom for ad-heavy clips
 ```
 
 **Key Features:**

--- a/docs/pycaps-followups.md
+++ b/docs/pycaps-followups.md
@@ -412,8 +412,10 @@ smoothing both from a single call site in `generate_subtitles_with_whisper`
 was cleaner than trying to unify the shapes.
 
 Config flows as a nested `timing_smoothing` dict from YAML through to the
-smoother kwargs. No flat Pydantic fields on `MergedSubtitleSettings` — the
-config audit caught that as dead code and they were removed.
+smoother kwargs. The flat per-knob fields that used to ride through the
+old `extra="allow"` accumulator are gone; `timing_smoothing` is now a
+typed field on the unified `SubtitleSettings`, kept loose-typed because
+the smoother itself owns the kwargs schema.
 
 The before/after fixture test is still open — the unit tests cover the
 logic exhaustively, but a visual comparison on a real voiceover would

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -173,7 +173,7 @@ High-level requirements for ContentEngineAI.
 - **Margin** from anchor edge (default 4%)
 - **Horizontal alignment**: left, center (default), right
 - Content-aware positioning relative to actual media bounds
-- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. Cross-platform union: top 220px, bottom 480px, left/right 90px on 1080x1920. Configurable globally in YAML and per-profile via `subtitle_safe_zone_*` overrides.
+- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. Cross-platform union: top 220px, bottom 480px, left/right 90px on 1080x1920. Configurable globally in YAML and per-profile via the nested `subtitle_settings.safe_zone` block (only the boundaries that differ need to be set).
 - Both engines enforce the safe zone: FFmpeg clamps subtitle width to safe zone boundaries, pycaps dynamically clamps `max_width_ratio` so centered text never extends past the right-side boundary (TikTok buttons). The clamping is automatic — no manual tuning needed per template.
 - Pycaps default position: bottom of safe zone (~75% of frame). Template's own alignment preserved unless explicitly overridden.
 
@@ -206,6 +206,9 @@ High-level requirements for ContentEngineAI.
 ### Profile System
 - **Precedence**: CLI > Profile > Global defaults
 - All visual, subtitle, and video settings configurable per profile
+- Subtitle overrides use a single nested `subtitle_settings` block on each profile; only fields that differ from the global value need to be set, and nested sub-blocks (`pycaps`, `two_part_subtitles`, `safe_zone`) deep-merge per-field rather than being replaced wholesale
+- Strict validation: unknown keys in subtitle YAML or profile overrides fail at config load with a typed error, instead of being silently dropped at render time
+- Legacy flat per-profile keys (`subtitle_anchor`, `pycaps_template`, `two_part_subtitles`, ...) still load with a deprecation warning during one-release migration window
 - Typed Pydantic models for merged settings
 - Deterministic random profile selection per product
 

--- a/docs/subtitle-config-cleanup.md
+++ b/docs/subtitle-config-cleanup.md
@@ -21,24 +21,31 @@ This document exists to:
 
 ## TL;DR
 
-All bugs fixed. Dead fields deleted, legacy block gone. Two refactors
-still open: §4.1 (collapse `MergedSubtitleSettings` + `UnifiedSubtitleConfig`)
-and §6 (rename canonical keys, gated on §4.1).
+All bugs fixed. Dead fields deleted, legacy block gone, models unified.
+The model collapse landed §4.1 (single `SubtitleSettings`), §4.3 (nested
+profile overrides via `PartialSubtitleSettings`), and §6 (canonical
+`max_duration` / `min_duration` names) in one PR. A migration shim still
+accepts legacy flat profile keys for one release with a `DeprecationWarning`;
+the bundled `config/video_production.yaml` profiles use the legacy shape
+and will move to the nested form in a follow-up cleanup.
 
 | # | Work item | Kind | Status | Effort |
 |---|---|---|---|---|
 | 1 | ~~Fix duration key namespace + width fraction passthrough~~ | ~~Bug~~ | **FIXED** (commit `c385df1`) | ~~30 min~~ |
 | 2 | ~~`UnifiedSubtitleGenerator` constructs fresh `PlatformSafeZone()` instead of reading config~~ | ~~Bug~~ | **FIXED** (PR #65) | ~~15 min~~ |
 | 3 | ~~Wire profile `subtitle_safe_zone_*` overrides into `_collect_overrides` field map~~ | ~~Bug~~ | **FIXED** (PR #65) | ~~15 min~~ |
-| 4 | Collapse `MergedSubtitleSettings` + `UnifiedSubtitleConfig` into one typed model | **Refactor** | Open | 1-2 days |
+| 4 | ~~Collapse `MergedSubtitleSettings` + `UnifiedSubtitleConfig` into one typed model~~ | ~~Refactor~~ | **DONE** | ~~1-2 days~~ |
 | 5 | ~~Nest `two_part_subtitles` as a typed sub-model instead of 14 flat fields~~ | ~~Refactor~~ | **DONE** | ~~0.5 day~~ |
 | 6 | ~~Move `style_presets` into the Pydantic model, delete the inline YAML re-read in `get_style_config()`~~ | ~~Refactor~~ | **DONE** | ~~0.5 day~~ |
 | 7 | ~~Move font and color pools from Python enums to YAML~~ | ~~Refactor~~ | **DONE** | ~~1 day~~ |
 | 8 | ~~Delete ~20 dead YAML keys and Pydantic fields~~ | ~~Cleanup~~ | **DONE** | ~~1 hour~~ |
 | 9 | ~~Remove the "Legacy Compatibility Settings" block in `subtitle_settings`~~ | ~~Cleanup~~ | **DONE** | ~~1 hour~~ |
-| 10 | Rename duplicate/confusing keys to canonical names | **Cleanup** | Open (gated on #4) | 1 hour |
+| 10 | ~~Rename duplicate/confusing keys to canonical names~~ | ~~Cleanup~~ | **DONE** (with #4) | ~~1 hour~~ |
 
-Remaining effort: roughly 1-2 days if §4.1 and §6 are both done.
+Remaining work: migrate the bundled `config/video_production.yaml` profiles
+from the legacy flat `subtitle_*` / `pycaps_*` / `two_part_subtitles` keys
+to the nested `subtitle_settings` block, then drop the migration shim in
+`VideoProfile._migrate_legacy_subtitle_keys`. Roughly 1 hour mechanical.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -358,8 +358,8 @@ for voice in voices.voices[:5]:
 2. **Timing Issues:**
    ```yaml
    subtitle_settings:
-     max_subtitle_duration: 2.5     # Shorter segments (seconds)
-     min_subtitle_duration: 0.6     # Floor so short words stay readable
+     max_duration: 2.5              # Shorter segments (seconds)
+     min_duration: 0.6              # Floor so short words stay readable
      max_words_per_line: 3          # Denser line breaks
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.41.0"
+version = "0.42.0"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/video/assembler/subtitle_builder.py
+++ b/src/video/assembler/subtitle_builder.py
@@ -129,10 +129,10 @@ class SubtitleGraphBuilder:
 
         settings_dict = self._get_effective_subtitle_settings()
 
-        from src.video.subtitle_positioning import UnifiedSubtitleConfig
+        from src.video.config.subtitle_models import SubtitleSettings
 
         try:
-            unified_config = UnifiedSubtitleConfig(**settings_dict)
+            unified_config = SubtitleSettings.from_legacy_dict(settings_dict)
             use_content_aware = unified_config.content_aware
         except Exception as e:
             logger.warning(f"Failed to parse subtitle settings, using fallback: {e}")
@@ -177,7 +177,7 @@ class SubtitleGraphBuilder:
         from src.video.subtitle_positioning import get_style_config
 
         try:
-            unified_config = UnifiedSubtitleConfig(**settings_dict)
+            unified_config = SubtitleSettings.from_legacy_dict(settings_dict)
             style_config = get_style_config(
                 preset=unified_config.style_preset,
                 config=unified_config,
@@ -294,10 +294,10 @@ class SubtitleGraphBuilder:
 
         settings_dict = self._get_effective_subtitle_settings()
 
-        from src.video.subtitle_positioning import UnifiedSubtitleConfig
+        from src.video.config.subtitle_models import SubtitleSettings
 
         try:
-            unified_config = UnifiedSubtitleConfig(**settings_dict)
+            unified_config = SubtitleSettings.from_legacy_dict(settings_dict)
             use_content_aware = unified_config.content_aware
         except Exception as e:
             logger.warning(f"Failed to parse subtitle settings, using fallback: {e}")
@@ -340,7 +340,7 @@ class SubtitleGraphBuilder:
                 )
 
                 try:
-                    upper_unified = UnifiedSubtitleConfig(**upper_settings)
+                    upper_unified = SubtitleSettings.from_legacy_dict(upper_settings)
                     upper_style_config = get_style_config(
                         preset=style_preset,
                         config=upper_unified,
@@ -489,7 +489,7 @@ class SubtitleGraphBuilder:
                 from src.video.subtitle_positioning import get_style_config
 
                 try:
-                    lower_unified = UnifiedSubtitleConfig(**lower_settings)
+                    lower_unified = SubtitleSettings.from_legacy_dict(lower_settings)
                     lower_style_config = get_style_config(
                         preset=lower_unified.style_preset,
                         config=lower_unified,
@@ -690,13 +690,11 @@ class SubtitleGraphBuilder:
 
             settings_dict = self._get_effective_subtitle_settings()
 
-            from src.video.subtitle_positioning import (
-                PositionAnchor,
-                UnifiedSubtitleConfig,
-            )
+            from src.video.config.subtitle_models import SubtitleSettings
+            from src.video.subtitle_positioning import PositionAnchor
 
             try:
-                unified_config = UnifiedSubtitleConfig(**settings_dict)
+                unified_config = SubtitleSettings.from_legacy_dict(settings_dict)
             except Exception as e:
                 logger.warning(f"Failed to parse unified subtitle config: {e}")
                 return original_ass_path

--- a/src/video/config/__init__.py
+++ b/src/video/config/__init__.py
@@ -54,9 +54,15 @@ from src.video.config.llm_settings import LLMSettings  # noqa: F401
 from src.video.config.subtitle_models import (  # noqa: F401
     ColorPoolEntry,
     FontPoolEntry,
+    PartialSubtitleSettings,
+    PlatformSafeZone,
+    Position,
+    PositionAnchor,
+    StylePreset,
     StylePresetConfig,
     SubtitleEffectsSettings,
     SubtitleSegmentationSettings,
+    SubtitleSettings,
 )
 
 # Re-export visual models
@@ -101,9 +107,15 @@ __all__ = [
     # Subtitle models
     "ColorPoolEntry",
     "FontPoolEntry",
+    "PartialSubtitleSettings",
+    "PlatformSafeZone",
+    "Position",
+    "PositionAnchor",
+    "StylePreset",
     "StylePresetConfig",
     "SubtitleEffectsSettings",
     "SubtitleSegmentationSettings",
+    "SubtitleSettings",
     # Core models
     "ApiSettings",
     "AttributionSettings",

--- a/src/video/config/core_models.py
+++ b/src/video/config/core_models.py
@@ -27,19 +27,18 @@ from src.video.config.constants import (
     FALLBACK_FONT_ALTERNATIVES,
     FONT_FILE_EXTENSIONS,
     FONT_REGULAR_SUFFIXES,
-    SAFE_ZONE_MAX_X,
-    SAFE_ZONE_MAX_Y,
-    SAFE_ZONE_MIN_X,
-    SAFE_ZONE_MIN_Y,
 )
 from src.video.config.llm_settings import LLMSettings
 from src.video.config.subtitle_models import (
     ColorPoolEntry,
     FontPoolEntry,
+    PlatformSafeZone,  # re-exported here for backward compat with existing imports
     StylePresetConfig,
     SubtitleEffectsSettings,
     SubtitleSegmentationSettings,
 )
+
+__all_reexported__ = ["PlatformSafeZone"]
 from src.video.config.visual_models import (
     CTADetectionSettings,
     MediaSettings,
@@ -221,28 +220,6 @@ class FilesystemSettings(BaseModel):
         [".mp4", ".avi", ".mov", ".mkv", ".webm"]
     )
     supported_audio_extensions: list[str] = Field([".wav", ".mp3", ".aac", ".flac"])
-
-
-class PlatformSafeZone(BaseModel):
-    """Safe zone boundaries to avoid platform UI overlays (fractions of frame).
-
-    Default values represent the cross-platform worst case for TikTok,
-    YouTube Shorts, and Instagram Reels on a 1080x1920 frame.
-    See docs/platform-safe-zones.md for per-platform breakdown.
-    """
-
-    min_x: float = Field(
-        default=SAFE_ZONE_MIN_X, description="Left boundary (fraction of width)"
-    )
-    max_x: float = Field(
-        default=SAFE_ZONE_MAX_X, description="Right boundary (fraction of width)"
-    )
-    min_y: float = Field(
-        default=SAFE_ZONE_MIN_Y, description="Top boundary (fraction of height)"
-    )
-    max_y: float = Field(
-        default=SAFE_ZONE_MAX_Y, description="Bottom boundary (fraction of height)"
-    )
 
 
 class TextRenderingSettings(BaseModel):

--- a/src/video/config/core_models.py
+++ b/src/video/config/core_models.py
@@ -769,93 +769,16 @@ class VideoConfig(BaseModel):
                 )
         merged_video = self.video_settings.model_copy(update=video_overrides)
 
-        # --- Subtitle settings: YAML dict + flattening + profile overrides ---
-        subtitle_data = self._build_subtitle_base()
-        subtitle_overrides = self._collect_overrides(
-            profile,
-            {
-                "subtitle_anchor": "anchor",
-                "subtitle_margin": "margin",
-                "subtitle_content_aware": "content_aware",
-                "subtitle_style_preset": "style_preset",
-                "subtitle_font_size_scale": "font_size_scale",
-                "subtitle_horizontal_alignment": "horizontal_alignment",
-                "subtitle_randomize_fonts": "randomize_fonts",
-                "subtitle_randomize_colors": "randomize_colors",
-                "subtitle_randomize_effects": "randomize_effects",
-                "subtitle_max_line_length": "max_line_length",
-                "subtitle_max_words_per_line": "max_words_per_line",
-                "subtitle_max_subtitle_width_fraction": "max_subtitle_width_fraction",
-                "subtitle_max_duration": "max_subtitle_duration",
-                "subtitle_min_duration": "min_subtitle_duration",
-                "subtitle_selected_font": "selected_font",
-                "subtitle_selected_color_pair": "selected_color_pair",
-            },
-        )
-        subtitle_data.update(subtitle_overrides)
-        if profile.subtitle_positioning:
-            subtitle_data.update(profile.subtitle_positioning)
-
-        # Apply per-profile safe zone overrides (subtitle_safe_zone_* fields).
-        # Build a PlatformSafeZone with profile values overriding the global.
-        sz_overrides: dict[str, float] = {}
-        for attr in ("min_x", "max_x", "min_y", "max_y"):
-            val = getattr(profile, f"subtitle_safe_zone_{attr}", None)
-            if val is not None:
-                sz_overrides[attr] = val
-        if sz_overrides:
-            base_sz = subtitle_data.get("safe_zone")
-            if isinstance(base_sz, PlatformSafeZone):
-                subtitle_data["safe_zone"] = base_sz.model_copy(update=sz_overrides)
-            else:
-                subtitle_data["safe_zone"] = PlatformSafeZone(**sz_overrides)
-
-        # Engine + nested pycaps profile overrides. Flat VideoProfile fields
-        # (pycaps_template, pycaps_renderer, ...) fold into the nested
-        # subtitle_data["pycaps"] dict so Pydantic can build PycapsSettings.
-        if profile.subtitle_engine is not None:
-            subtitle_data["subtitle_engine"] = profile.subtitle_engine
-        pycaps_profile_overrides: dict[str, Any] = {}
-        profile_pycaps_field_map = {
-            "pycaps_template": "template_name",
-            "pycaps_template_pool": "template_pool",
-            "pycaps_renderer": "renderer",
-            "pycaps_max_width_ratio": "max_width_ratio",
-            "pycaps_vertical_align": "vertical_align",
-            "pycaps_vertical_align_offset": "vertical_align_offset",
-            "pycaps_fallback_policy": "fallback_policy",
-        }
-        for profile_field, pycaps_field in profile_pycaps_field_map.items():
-            value = getattr(profile, profile_field, None)
-            if value is not None:
-                pycaps_profile_overrides[pycaps_field] = value
-        if pycaps_profile_overrides:
-            base_pycaps = subtitle_data.get("pycaps") or {}
-            if not isinstance(base_pycaps, dict):
-                base_pycaps = (
-                    base_pycaps.model_dump()
-                    if hasattr(base_pycaps, "model_dump")
-                    else dict(base_pycaps)
-                )
-            base_pycaps.update(pycaps_profile_overrides)
-            subtitle_data["pycaps"] = base_pycaps
-
-        # Two-part subtitles profile override: nested dict, deep-merged onto
-        # the global block so profiles only need to specify fields that differ.
-        if profile.two_part_subtitles:
-            base_two_part = subtitle_data.get("two_part_subtitles") or {}
-            if not isinstance(base_two_part, dict):
-                base_two_part = dict(base_two_part)
-            subtitle_data["two_part_subtitles"] = _deep_merge(
-                base_two_part, profile.two_part_subtitles
-            )
-
-        # Build the unified SubtitleSettings. from_legacy_dict handles the
-        # historical renames (max_subtitle_duration → max_duration, etc.) and
-        # drops runtime-only underscore keys so strict validation passes.
+        # --- Subtitle settings: YAML dict -> SubtitleSettings, then deep-merge
+        # the profile's nested subtitle_settings PartialSubtitleSettings on top.
         from src.video.config.subtitle_models import SubtitleSettings
 
+        subtitle_data = self._build_subtitle_base()
+        if profile.subtitle_positioning:
+            subtitle_data.update(profile.subtitle_positioning)
         merged_subtitle = SubtitleSettings.from_legacy_dict(subtitle_data)
+        if profile.subtitle_settings is not None:
+            merged_subtitle = profile.subtitle_settings.merge_into(merged_subtitle)
 
         # --- Profile info ---
         profile_info = ProfileInfo(

--- a/src/video/config/core_models.py
+++ b/src/video/config/core_models.py
@@ -44,7 +44,6 @@ from src.video.config.visual_models import (
     MediaSettings,
     MediaValidationSettings,
     MergedProfileSettings,
-    MergedSubtitleSettings,
     ProfileInfo,
     StockMediaSettings,
     VideoProcessingSettings,
@@ -851,7 +850,12 @@ class VideoConfig(BaseModel):
                 base_two_part, profile.two_part_subtitles
             )
 
-        merged_subtitle = MergedSubtitleSettings(**subtitle_data)
+        # Build the unified SubtitleSettings. from_legacy_dict handles the
+        # historical renames (max_subtitle_duration → max_duration, etc.) and
+        # drops runtime-only underscore keys so strict validation passes.
+        from src.video.config.subtitle_models import SubtitleSettings
+
+        merged_subtitle = SubtitleSettings.from_legacy_dict(subtitle_data)
 
         # --- Profile info ---
         profile_info = ProfileInfo(
@@ -925,7 +929,7 @@ class VideoConfig(BaseModel):
         """Build base subtitle settings dict from global YAML config."""
         ss = self.subtitle_settings
 
-        return {
+        base: dict[str, Any] = {
             "anchor": ss["anchor"],
             "margin": ss["margin"],
             "content_aware": ss["content_aware"],
@@ -968,11 +972,12 @@ class VideoConfig(BaseModel):
             # Pycaps engine selector + nested sub-settings (YAML layer)
             "subtitle_engine": ss.get("subtitle_engine", "ffmpeg"),
             "pycaps": ss.get("pycaps"),
-            # Safe zone from text_rendering config (global YAML layer)
-            "safe_zone": (
-                self.text_rendering.safe_zone if self.text_rendering else None
-            ),
         }
+        # Safe zone only included when the global text_rendering block defined
+        # one — otherwise SubtitleSettings uses its own PlatformSafeZone default.
+        if self.text_rendering is not None:
+            base["safe_zone"] = self.text_rendering.safe_zone
+        return base
 
     def get_product_paths(self, product_id: str, profile_name: str) -> dict[str, Path]:
         """Generate all paths for a product using simplified product-oriented structure.

--- a/src/video/config/subtitle_models.py
+++ b/src/video/config/subtitle_models.py
@@ -357,16 +357,15 @@ class PycapsSettings(BaseModel):
 # round-trip through dict.get(...) between the two models was the hiding place
 # for silent-drop bugs like the one tracked in subtitle-config-cleanup.md §3.1.
 #
-# Canonical names (max_duration / min_duration, two_part) — old names like
-# max_subtitle_duration and two_part_subtitles are translated by
-# from_legacy_dict() so existing YAML keeps loading.
+# Canonical names (max_duration, min_duration) — old names like
+# max_subtitle_duration are translated by from_legacy_dict() so existing
+# YAML keeps loading.
 
 # YAML keys that ``from_legacy_dict`` either renames or drops outright.
 # Each entry: legacy key -> canonical key (or None to drop with a warning).
 _LEGACY_RENAMES: dict[str, str] = {
     "max_subtitle_duration": "max_duration",
     "min_subtitle_duration": "min_duration",
-    "two_part_subtitles": "two_part",
 }
 
 # Keys that have no consumer on SubtitleSettings and used to live on
@@ -425,9 +424,19 @@ class SubtitleSettings(BaseModel):
     save_srt_with_video: bool = True
     script_paths: list[str] = Field(default_factory=list)
 
+    # ---- Quality ----
+    subtitle_similarity_threshold: float = Field(0.70, ge=0.0, le=1.0)
+
+    # ---- Whisper timing post-processing (see subtitle_timing_smoother.py) ----
+    # Kept as a free-form dict because the smoother reads these as kwargs;
+    # the project's smoother module owns the schema, not this model.
+    timing_smoothing: dict[str, Any] = Field(default_factory=dict)
+
     # ---- Nested ----
     pycaps: PycapsSettings | None = None
-    two_part: TwoPartSubtitleSettings = Field(default_factory=TwoPartSubtitleSettings)
+    two_part_subtitles: TwoPartSubtitleSettings = Field(
+        default_factory=TwoPartSubtitleSettings
+    )
 
     @classmethod
     def from_legacy_dict(cls, data: dict[str, Any]) -> "SubtitleSettings":
@@ -442,6 +451,11 @@ class SubtitleSettings(BaseModel):
         """
         translated: dict[str, Any] = {}
         for key, value in data.items():
+            # Underscore-prefixed keys are runtime-only side channels
+            # (for example "_upper_use_full_duration" threaded through
+            # TwoPartSubtitleHandler). They never belong in the typed model.
+            if key.startswith("_"):
+                continue
             if key in _LEGACY_DROPS:
                 continue
             if key in _LEGACY_RENAMES:
@@ -494,8 +508,10 @@ class PartialSubtitleSettings(BaseModel):
     temp_subtitle_filename: str | None = None
     save_srt_with_video: bool | None = None
     script_paths: list[str] | None = None
+    subtitle_similarity_threshold: float | None = None
+    timing_smoothing: dict[str, Any] | None = None
     pycaps: dict[str, Any] | None = None
-    two_part: dict[str, Any] | None = None
+    two_part_subtitles: dict[str, Any] | None = None
 
     def merge_into(self, base: SubtitleSettings) -> SubtitleSettings:
         """Return a copy of base with non-None partial fields applied.
@@ -513,10 +529,10 @@ class PartialSubtitleSettings(BaseModel):
                 base_pycaps = base.pycaps.model_dump() if base.pycaps else {}
                 merged = _deep_merge_dicts(base_pycaps, override)
                 updates["pycaps"] = PycapsSettings(**merged)
-            elif field_name == "two_part":
-                base_two_part = base.two_part.model_dump()
+            elif field_name == "two_part_subtitles":
+                base_two_part = base.two_part_subtitles.model_dump()
                 merged = _deep_merge_dicts(base_two_part, override)
-                updates["two_part"] = TwoPartSubtitleSettings(**merged)
+                updates["two_part_subtitles"] = TwoPartSubtitleSettings(**merged)
             elif field_name == "safe_zone":
                 base_safe_zone = base.safe_zone.model_dump()
                 merged = _deep_merge_dicts(base_safe_zone, override)

--- a/src/video/config/subtitle_models.py
+++ b/src/video/config/subtitle_models.py
@@ -1,14 +1,77 @@
 # src/video/config/subtitle_models.py
-"""Subtitle configuration models for effects and segmentation."""
+"""Subtitle configuration models.
 
+Holds the leaf types used across the subtitle pipeline: effect tuning,
+segmentation, style presets, font/color pools, two-part / pycaps blocks,
+the platform safe zone, and the unified ``SubtitleSettings`` model that
+both the config layer and the runtime generator share.
+"""
+
+import logging
+from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from src.video.config.constants import (
     FONT_FILE_EXTENSIONS,
     FONT_REGULAR_SUFFIXES,
+    SAFE_ZONE_MAX_X,
+    SAFE_ZONE_MAX_Y,
+    SAFE_ZONE_MIN_X,
+    SAFE_ZONE_MIN_Y,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class PositionAnchor(str, Enum):
+    """Anchor points for subtitle positioning."""
+
+    TOP = "top"
+    CENTER = "center"
+    BOTTOM = "bottom"
+    ABOVE_CONTENT = "above_content"
+    BELOW_CONTENT = "below_content"
+
+
+class StylePreset(str, Enum):
+    """Predefined subtitle style presets."""
+
+    MINIMAL = "minimal"
+    MODERN = "modern"
+    BOLD = "bold"
+    ANIMATED = "animated"
+    RANDOM = "random"
+
+
+class Position(BaseModel):
+    """Pixel-fraction position used for manual subtitle placement overrides."""
+
+    x: float = Field(..., ge=0.0, le=1.0)
+    y: float = Field(..., ge=0.0, le=1.0)
+
+
+class PlatformSafeZone(BaseModel):
+    """Safe zone boundaries to avoid platform UI overlays (fractions of frame).
+
+    Default values represent the cross-platform worst case for TikTok,
+    YouTube Shorts, and Instagram Reels on a 1080x1920 frame.
+    See docs/platform-safe-zones.md for per-platform breakdown.
+    """
+
+    min_x: float = Field(
+        default=SAFE_ZONE_MIN_X, description="Left boundary (fraction of width)"
+    )
+    max_x: float = Field(
+        default=SAFE_ZONE_MAX_X, description="Right boundary (fraction of width)"
+    )
+    min_y: float = Field(
+        default=SAFE_ZONE_MIN_Y, description="Top boundary (fraction of height)"
+    )
+    max_y: float = Field(
+        default=SAFE_ZONE_MAX_Y, description="Bottom boundary (fraction of height)"
+    )
 
 
 class SubtitleEffectsSettings(BaseModel):
@@ -283,3 +346,194 @@ class PycapsSettings(BaseModel):
             "the video without subtitles (not recommended)."
         ),
     )
+
+
+# ============================================================================
+# Unified subtitle settings model
+# ============================================================================
+# Single source of truth for both the config-layer merge output and the runtime
+# generator input. Replaces the historical pair MergedSubtitleSettings (config
+# side, extra="allow") and UnifiedSubtitleConfig (runtime side, strict). The
+# round-trip through dict.get(...) between the two models was the hiding place
+# for silent-drop bugs like the one tracked in subtitle-config-cleanup.md §3.1.
+#
+# Canonical names (max_duration / min_duration, two_part) — old names like
+# max_subtitle_duration and two_part_subtitles are translated by
+# from_legacy_dict() so existing YAML keeps loading.
+
+# YAML keys that ``from_legacy_dict`` either renames or drops outright.
+# Each entry: legacy key -> canonical key (or None to drop with a warning).
+_LEGACY_RENAMES: dict[str, str] = {
+    "max_subtitle_duration": "max_duration",
+    "min_subtitle_duration": "min_duration",
+    "two_part_subtitles": "two_part",
+}
+
+# Keys that have no consumer on SubtitleSettings and used to live on
+# MergedSubtitleSettings via extra="allow". Dropped silently.
+_LEGACY_DROPS: frozenset[str] = frozenset(
+    {
+        "available_fonts",
+        "available_color_combinations",
+    }
+)
+
+
+class SubtitleSettings(BaseModel):
+    """Unified subtitle configuration shared by config and runtime layers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # ---- Engine + format ----
+    enabled: bool = True
+    subtitle_engine: Literal["ffmpeg", "pycaps"] = "ffmpeg"
+    subtitle_format: Literal["srt", "ass"] = "srt"
+
+    # ---- Positioning ----
+    anchor: PositionAnchor = PositionAnchor.BOTTOM
+    margin: float = Field(0.1, ge=0.0, le=0.5)
+    content_aware: bool = True
+    horizontal_alignment: Literal["left", "center", "right"] = "center"
+    safe_zone: PlatformSafeZone = Field(default_factory=PlatformSafeZone)
+    custom_position: Position | None = None
+
+    # ---- Style ----
+    style_preset: StylePreset = StylePreset.MODERN
+    font_size_scale: float = Field(1.0, ge=0.5, le=2.0)
+
+    # ---- Text formatting (canonical names) ----
+    max_line_length: int = Field(38, ge=1)
+    max_words_per_line: int = Field(3, ge=0)
+    max_subtitle_width_fraction: float = Field(0.80, ge=0.0, le=1.0)
+    max_duration: float = Field(2.5, gt=0)
+    min_duration: float = Field(0.6, gt=0)
+
+    # ---- Infrastructure (load-bearing for the rendering pipeline) ----
+    font_directory: str = "static/fonts"
+    font_size_percent: float = Field(0.075, ge=0.0, le=1.0)
+
+    # ---- Randomization ----
+    randomize_fonts: bool = False
+    randomize_colors: bool = False
+    randomize_effects: bool = False
+    selected_font: str | None = None
+    selected_color_pair: str | None = None
+
+    # ---- Output ----
+    temp_subtitle_dir: str = "temp"
+    temp_subtitle_filename: str = "captions.srt"
+    save_srt_with_video: bool = True
+    script_paths: list[str] = Field(default_factory=list)
+
+    # ---- Nested ----
+    pycaps: PycapsSettings | None = None
+    two_part: TwoPartSubtitleSettings = Field(default_factory=TwoPartSubtitleSettings)
+
+    @classmethod
+    def from_legacy_dict(cls, data: dict[str, Any]) -> "SubtitleSettings":
+        """Translate a MergedSubtitleSettings dump (or raw merged YAML dict)
+        into a SubtitleSettings instance.
+
+        Handles renames from the legacy field names (`max_subtitle_duration`
+        → `max_duration`, etc.) and silently drops keys that no longer exist
+        on the unified model (the old `extra="allow"` accumulators).
+        Unknown keys not in the rename or drop lists raise a ValidationError
+        thanks to ``extra="forbid"``.
+        """
+        translated: dict[str, Any] = {}
+        for key, value in data.items():
+            if key in _LEGACY_DROPS:
+                continue
+            if key in _LEGACY_RENAMES:
+                canonical = _LEGACY_RENAMES[key]
+                if canonical in translated:
+                    # Canonical name already present in the input; legacy
+                    # name should not override it.
+                    continue
+                translated[canonical] = value
+            else:
+                translated[key] = value
+        return cls(**translated)
+
+
+class PartialSubtitleSettings(BaseModel):
+    """All-optional variant of SubtitleSettings used by VideoProfile overrides.
+
+    Every field defaults to ``None``; ``merge_into(base)`` deep-merges only
+    the non-None fields onto a base ``SubtitleSettings``. Nested models
+    (``pycaps``, ``two_part``, ``safe_zone``) merge recursively so a profile
+    can tweak a single nested field without restating the whole block.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = None
+    subtitle_engine: Literal["ffmpeg", "pycaps"] | None = None
+    subtitle_format: Literal["srt", "ass"] | None = None
+    anchor: PositionAnchor | None = None
+    margin: float | None = None
+    content_aware: bool | None = None
+    horizontal_alignment: Literal["left", "center", "right"] | None = None
+    safe_zone: dict[str, Any] | None = None
+    custom_position: dict[str, Any] | None = None
+    style_preset: StylePreset | None = None
+    font_size_scale: float | None = None
+    max_line_length: int | None = None
+    max_words_per_line: int | None = None
+    max_subtitle_width_fraction: float | None = None
+    max_duration: float | None = None
+    min_duration: float | None = None
+    font_directory: str | None = None
+    font_size_percent: float | None = None
+    randomize_fonts: bool | None = None
+    randomize_colors: bool | None = None
+    randomize_effects: bool | None = None
+    selected_font: str | None = None
+    selected_color_pair: str | None = None
+    temp_subtitle_dir: str | None = None
+    temp_subtitle_filename: str | None = None
+    save_srt_with_video: bool | None = None
+    script_paths: list[str] | None = None
+    pycaps: dict[str, Any] | None = None
+    two_part: dict[str, Any] | None = None
+
+    def merge_into(self, base: SubtitleSettings) -> SubtitleSettings:
+        """Return a copy of base with non-None partial fields applied.
+
+        Nested model fields (pycaps, two_part, safe_zone) are dict-typed on
+        the partial side; we deep-merge them onto the base nested model and
+        re-validate via ``model_copy``.
+        """
+        updates: dict[str, Any] = {}
+        for field_name in self.__class__.model_fields:
+            override = getattr(self, field_name)
+            if override is None:
+                continue
+            if field_name == "pycaps":
+                base_pycaps = base.pycaps.model_dump() if base.pycaps else {}
+                merged = _deep_merge_dicts(base_pycaps, override)
+                updates["pycaps"] = PycapsSettings(**merged)
+            elif field_name == "two_part":
+                base_two_part = base.two_part.model_dump()
+                merged = _deep_merge_dicts(base_two_part, override)
+                updates["two_part"] = TwoPartSubtitleSettings(**merged)
+            elif field_name == "safe_zone":
+                base_safe_zone = base.safe_zone.model_dump()
+                merged = _deep_merge_dicts(base_safe_zone, override)
+                updates["safe_zone"] = PlatformSafeZone(**merged)
+            elif field_name == "custom_position":
+                updates["custom_position"] = Position(**override)
+            else:
+                updates[field_name] = override
+        return base.model_copy(update=updates)
+
+
+def _deep_merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursive dict merge: override wins for scalars; dicts merge per-key."""
+    out = dict(base)
+    for key, value in override.items():
+        if key in out and isinstance(out[key], dict) and isinstance(value, dict):
+            out[key] = _deep_merge_dicts(out[key], value)
+        else:
+            out[key] = value
+    return out

--- a/src/video/config/visual_models.py
+++ b/src/video/config/visual_models.py
@@ -3,13 +3,13 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from src.video.config.constants import (
     ASSEMBLER_IMAGE_LOOP,
     ASSEMBLER_PAD_COLOR,
 )
-from src.video.config.subtitle_models import PycapsSettings, TwoPartSubtitleSettings
+from src.video.config.subtitle_models import SubtitleSettings
 
 
 class CTADetectionSettings(BaseModel):
@@ -423,64 +423,6 @@ class VideoProfile(BaseModel):
     )
 
 
-class MergedSubtitleSettings(BaseModel):
-    """Merged subtitle settings (global + profile overrides)."""
-
-    model_config = ConfigDict(extra="allow")
-
-    # Rendering engine selector. "ffmpeg" (default) uses the existing
-    # SRT/ASS + libass pipeline. "pycaps" burns animated captions via the
-    # pycaps library as a post-assembly step. See docs/pycaps-subtitles.md.
-    subtitle_engine: Literal["ffmpeg", "pycaps"] = "ffmpeg"
-
-    # Nested settings consumed only when subtitle_engine == "pycaps".
-    pycaps: PycapsSettings | None = None
-
-    # Core positioning
-    anchor: str = "bottom"
-    margin: float = 0.1
-    content_aware: bool = True
-    style_preset: str = "modern"
-    font_size_scale: float = 1.0
-    horizontal_alignment: str = "center"
-
-    randomize_effects: bool = False
-
-    # Text formatting
-    max_line_length: int = 38
-    max_words_per_line: int = 3
-    max_subtitle_duration: float = 4.5
-    min_subtitle_duration: float = 0.4
-    max_subtitle_width_fraction: float = 0.80
-
-    # Infrastructure (not preset-owned)
-    enabled: bool = True
-    font_directory: str = "static/fonts"
-    font_size_percent: float = 0.05
-
-    # Randomization
-    randomize_fonts: bool = False
-    randomize_colors: bool = False
-    available_fonts: list[Any] = Field(default_factory=list)
-    available_color_combinations: list[Any] = Field(default_factory=list)
-
-    # Output
-    temp_subtitle_dir: str = "temp"
-    temp_subtitle_filename: str = "captions.srt"
-    save_srt_with_video: bool = True
-    subtitle_format: str = "srt"
-    script_paths: list[Any] = Field(default_factory=list)
-
-    # Manual overrides
-    selected_font: str | None = None
-    selected_color_pair: str | None = None
-
-    # Two-part subtitle system (upper static line + lower voiceover line)
-    two_part_subtitles: TwoPartSubtitleSettings = Field(
-        default_factory=TwoPartSubtitleSettings
-    )
-
-
 class ProfileInfo(BaseModel):
     """Profile metadata."""
 
@@ -499,7 +441,7 @@ class MergedProfileSettings(BaseModel):
     """Typed container for merged profile settings."""
 
     video_settings: "VideoSettings"
-    subtitle_settings: MergedSubtitleSettings
+    subtitle_settings: SubtitleSettings
     profile: ProfileInfo
 
 

--- a/src/video/config/visual_models.py
+++ b/src/video/config/visual_models.py
@@ -1,6 +1,8 @@
 # src/video/config/visual_models.py
 """Visual configuration models for video, images, and media settings."""
 
+import logging
+import warnings
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -9,7 +11,55 @@ from src.video.config.constants import (
     ASSEMBLER_IMAGE_LOOP,
     ASSEMBLER_PAD_COLOR,
 )
-from src.video.config.subtitle_models import SubtitleSettings
+from src.video.config.subtitle_models import (
+    PartialSubtitleSettings,
+    SubtitleSettings,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Legacy flat field names on VideoProfile (subtitle_*/pycaps_*/two_part_*)
+# mapped to their nested PartialSubtitleSettings field path. Used by the
+# @model_validator on VideoProfile to migrate profile YAML at load time.
+# The values are tuples: (path, value_transform). Path is dotted so
+# "pycaps.template_name" lands inside the nested pycaps dict.
+_LEGACY_FLAT_TO_NESTED: dict[str, str] = {
+    "subtitle_anchor": "anchor",
+    "subtitle_margin": "margin",
+    "subtitle_content_aware": "content_aware",
+    "subtitle_style_preset": "style_preset",
+    "subtitle_font_size_scale": "font_size_scale",
+    "subtitle_horizontal_alignment": "horizontal_alignment",
+    "subtitle_randomize_fonts": "randomize_fonts",
+    "subtitle_randomize_colors": "randomize_colors",
+    "subtitle_randomize_effects": "randomize_effects",
+    "subtitle_max_line_length": "max_line_length",
+    "subtitle_max_words_per_line": "max_words_per_line",
+    "subtitle_max_subtitle_width_fraction": "max_subtitle_width_fraction",
+    "subtitle_max_duration": "max_duration",
+    "subtitle_min_duration": "min_duration",
+    "subtitle_selected_font": "selected_font",
+    "subtitle_selected_color_pair": "selected_color_pair",
+    "subtitle_engine": "subtitle_engine",
+}
+
+_LEGACY_SAFE_ZONE_FIELDS = (
+    "subtitle_safe_zone_min_x",
+    "subtitle_safe_zone_max_x",
+    "subtitle_safe_zone_min_y",
+    "subtitle_safe_zone_max_y",
+)
+
+_LEGACY_PYCAPS_FIELDS: dict[str, str] = {
+    "pycaps_template": "template_name",
+    "pycaps_template_pool": "template_pool",
+    "pycaps_renderer": "renderer",
+    "pycaps_max_width_ratio": "max_width_ratio",
+    "pycaps_vertical_align": "vertical_align",
+    "pycaps_vertical_align_offset": "vertical_align_offset",
+    "pycaps_fallback_policy": "fallback_policy",
+}
 
 
 class CTADetectionSettings(BaseModel):
@@ -282,145 +332,83 @@ class VideoProfile(BaseModel):
     )
 
     # ---- PER-PROFILE SUBTITLE SETTINGS ----
-    # Complete unified subtitle configuration overrides
-    subtitle_anchor: str | None = Field(
+    # Single nested override block. Replaces the historical 30+ flat
+    # subtitle_*/pycaps_*/two_part_subtitles_* fields. Profile YAML written
+    # in the legacy flat shape is migrated at load time by the
+    # _migrate_legacy_subtitle_keys validator below.
+    subtitle_settings: PartialSubtitleSettings | None = Field(
         None,
         description=(
-            "Override subtitle anchor: top, center, bottom, "
-            "above_content, below_content"
-        ),
-    )
-    subtitle_margin: float | None = Field(
-        None,
-        description="Override subtitle margin as fraction of frame height (0.0-0.5)",
-    )
-    subtitle_content_aware: bool | None = Field(
-        None, description="Override content-aware positioning setting"
-    )
-    subtitle_style_preset: str | None = Field(
-        None,
-        description="Override style preset: minimal, modern, bold, random",
-    )
-    subtitle_font_size_scale: float | None = Field(
-        None, description="Override font size scale factor (0.5-2.0)"
-    )
-    subtitle_horizontal_alignment: str | None = Field(
-        None, description="Override text alignment: left, center, right"
-    )
-
-    # Platform safe zone overrides (per-profile, fractions of frame)
-    subtitle_safe_zone_min_x: float | None = Field(
-        None, description="Override left safe zone boundary"
-    )
-    subtitle_safe_zone_max_x: float | None = Field(
-        None, description="Override right safe zone boundary"
-    )
-    subtitle_safe_zone_min_y: float | None = Field(
-        None, description="Override top safe zone boundary"
-    )
-    subtitle_safe_zone_max_y: float | None = Field(
-        None, description="Override bottom safe zone boundary"
-    )
-
-    subtitle_randomize_fonts: bool | None = Field(
-        None, description="Override font randomization setting"
-    )
-    subtitle_randomize_colors: bool | None = Field(
-        None, description="Override color randomization setting"
-    )
-    subtitle_randomize_effects: bool | None = Field(
-        None, description="Override effect randomization setting"
-    )
-
-    # Text formatting overrides
-    subtitle_max_line_length: int | None = Field(
-        None, description="Override maximum characters per subtitle line"
-    )
-    subtitle_max_words_per_line: int | None = Field(
-        None,
-        description=(
-            "Override maximum words per subtitle line (0 to disable word-based limit)"
-        ),
-    )
-    subtitle_max_subtitle_width_fraction: float | None = Field(
-        None,
-        description=(
-            "Override max subtitle width as fraction of frame width (0.0-1.0)"
-        ),
-    )
-    subtitle_max_duration: float | None = Field(
-        None, description="Override maximum subtitle duration in seconds"
-    )
-    subtitle_min_duration: float | None = Field(
-        None, description="Override minimum subtitle duration in seconds"
-    )
-
-    # Manual selection overrides (for testing/debugging)
-    subtitle_selected_font: str | None = Field(
-        None, description="Override with specific font (bypasses randomization)"
-    )
-    subtitle_selected_color_pair: str | None = Field(
-        None, description="Override with specific color pair name"
-    )
-
-    # ---- TWO-PART SUBTITLE SYSTEM ----
-    # Profile-level nested override. Merges (deep, per-field) onto the global
-    # subtitle_settings.two_part_subtitles block during get_profile_merged_settings.
-    # Shape matches TwoPartSubtitleSettings (enabled + upper_line + lower_line).
-    two_part_subtitles: dict[str, Any] | None = Field(
-        None,
-        description=(
-            "Nested override for two_part_subtitles. Partial dict merged onto "
-            "the global block; missing keys inherit the global value."
+            "Nested partial override for the global SubtitleSettings. Only "
+            "non-None fields apply; nested models (pycaps, two_part_subtitles, "
+            "safe_zone) deep-merge onto the base. See PartialSubtitleSettings."
         ),
     )
 
-    # ---- PER-PROFILE PYCAPS SUBTITLE ENGINE SETTINGS ----
-    # Opt-in animated captions. See src/video/config/subtitle_models.py
-    # PycapsSettings for semantics. Non-null values override the global
-    # subtitle_settings.pycaps block during profile merge.
-    subtitle_engine: Literal["ffmpeg", "pycaps"] | None = Field(
-        None,
-        description=(
-            "Override subtitle rendering engine for this profile. "
-            "'ffmpeg' = existing SRT/ASS path. 'pycaps' = burn animated "
-            "CSS captions post-assembly."
-        ),
-    )
-    pycaps_template: str | None = Field(
-        None,
-        description=(
-            "Override pycaps fixed template name (word-focus, hype, minimalist, etc.)"
-        ),
-    )
-    pycaps_template_pool: list[str] | None = Field(
-        None,
-        description="Override pycaps template pool for deterministic per-product pick",
-    )
-    pycaps_renderer: Literal["css", "pictex"] | None = Field(
-        None,
-        description="Override pycaps renderer: css (Chromium) or pictex (browserless)",
-    )
-    pycaps_max_width_ratio: float | None = Field(
-        None,
-        ge=0.0,
-        le=1.0,
-        description="Override pycaps max caption width as fraction of frame",
-    )
-    pycaps_vertical_align: Literal["top", "center", "bottom"] | None = Field(
-        None, description="Override pycaps vertical anchor"
-    )
-    pycaps_vertical_align_offset: float | None = Field(
-        None,
-        ge=-1.0,
-        le=1.0,
-        description=(
-            "Override the derived offset from VisualBounds with a manual value"
-        ),
-    )
-    pycaps_fallback_policy: Literal["warn_and_skip", "raise"] | None = Field(
-        None, description="Override pycaps failure policy"
-    )
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_subtitle_keys(cls, data: Any) -> Any:
+        """Translate legacy flat subtitle_*/pycaps_*/two_part_subtitles_* keys
+        into the nested ``subtitle_settings`` block at load time.
+
+        Kept for one release so external profile YAML doesn't break. Logs
+        a DeprecationWarning naming each migrated key. Remove after the
+        documented migration window.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        nested = dict(data.get("subtitle_settings") or {})
+        legacy_seen: list[str] = []
+
+        for legacy_key, target_field in _LEGACY_FLAT_TO_NESTED.items():
+            if legacy_key in data and data[legacy_key] is not None:
+                nested.setdefault(target_field, data[legacy_key])
+                legacy_seen.append(legacy_key)
+
+        safe_zone_block = dict(nested.get("safe_zone") or {})
+        for sz_key in _LEGACY_SAFE_ZONE_FIELDS:
+            if sz_key in data and data[sz_key] is not None:
+                # subtitle_safe_zone_min_x -> min_x
+                short = sz_key.removeprefix("subtitle_safe_zone_")
+                safe_zone_block.setdefault(short, data[sz_key])
+                legacy_seen.append(sz_key)
+        if safe_zone_block:
+            nested["safe_zone"] = safe_zone_block
+
+        pycaps_block = dict(nested.get("pycaps") or {})
+        for pc_key, target_field in _LEGACY_PYCAPS_FIELDS.items():
+            if pc_key in data and data[pc_key] is not None:
+                pycaps_block.setdefault(target_field, data[pc_key])
+                legacy_seen.append(pc_key)
+        if pycaps_block:
+            nested["pycaps"] = pycaps_block
+
+        if "two_part_subtitles" in data and isinstance(
+            data["two_part_subtitles"], dict
+        ):
+            existing = nested.get("two_part_subtitles") or {}
+            nested["two_part_subtitles"] = {
+                **data["two_part_subtitles"],
+                **existing,
+            }
+            legacy_seen.append("two_part_subtitles")
+
+        if legacy_seen:
+            warnings.warn(
+                "VideoProfile: legacy flat subtitle keys are deprecated; "
+                "migrate to a nested 'subtitle_settings' block. Migrated "
+                f"this run: {sorted(set(legacy_seen))}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            for key in set(legacy_seen):
+                data.pop(key, None)
+
+        if nested:
+            data["subtitle_settings"] = nested
+
+        return data
 
 
 class ProfileInfo(BaseModel):

--- a/src/video/config_validator.py
+++ b/src/video/config_validator.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import Any
 
 from src.video.config import VideoConfig
+from src.video.config.subtitle_models import SubtitleSettings
 from src.video.subtitle_positioning import (
     PositionAnchor,
     StylePreset,
-    create_unified_config_from_settings,
 )
 
 logger = logging.getLogger(__name__)
@@ -396,7 +396,7 @@ class VideoConfigValidator:
                 if hasattr(subtitle_settings, "__dict__")
                 else subtitle_settings
             )
-            unified_config = create_unified_config_from_settings(settings_dict)
+            unified_config = SubtitleSettings.from_legacy_dict(settings_dict)
 
             # Validate anchor value
             if hasattr(unified_config, "anchor"):

--- a/src/video/subtitle_positioning.py
+++ b/src/video/subtitle_positioning.py
@@ -7,7 +7,6 @@ that replaces the complex multi-mode system with a single flexible configuration
 import contextlib
 import logging
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -18,37 +17,18 @@ from src.video.config.constants import (
     SUBTITLE_MAX_FONT_SIZE,
     SUBTITLE_MIN_FONT_SIZE,
 )
-from src.video.config.core_models import PlatformSafeZone
+
+# Re-exports of leaf types that moved into subtitle_models. Kept here so
+# existing imports (`from src.video.subtitle_positioning import PositionAnchor`)
+# keep working without rippling through the codebase.
+from src.video.config.subtitle_models import (  # noqa: F401
+    PlatformSafeZone,
+    Position,
+    PositionAnchor,
+    StylePreset,
+)
 
 logger = logging.getLogger(__name__)
-
-
-class PositionAnchor(str, Enum):
-    """Anchor points for subtitle positioning."""
-
-    TOP = "top"
-    CENTER = "center"
-    BOTTOM = "bottom"
-    ABOVE_CONTENT = "above_content"  # Position above visual content
-    BELOW_CONTENT = "below_content"  # Position below visual content
-
-
-class StylePreset(str, Enum):
-    """Predefined subtitle style presets."""
-
-    MINIMAL = "minimal"  # Clean, simple styling
-    MODERN = "modern"  # Contemporary look with effects
-    BOLD = "bold"  # High contrast, bold styling
-    ANIMATED = "animated"  # Full animations and dynamic effects
-    RANDOM = "random"  # Random styling with one random effect
-
-
-@dataclass
-class Position:
-    """Simple position coordinates."""
-
-    x: float  # Horizontal position (0.0-1.0 as fraction of width)
-    y: float  # Vertical position (0.0-1.0 as fraction of height)
 
 
 @dataclass

--- a/src/video/subtitle_positioning.py
+++ b/src/video/subtitle_positioning.py
@@ -26,6 +26,7 @@ from src.video.config.subtitle_models import (  # noqa: F401
     Position,
     PositionAnchor,
     StylePreset,
+    SubtitleSettings,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,83 +56,9 @@ def clamp_to_safe_zone(
     return clamped_x, clamped_y
 
 
-class UnifiedSubtitleConfig(BaseModel):
-    """Simplified, unified subtitle configuration."""
-
-    # Core positioning
-    anchor: PositionAnchor = Field(
-        PositionAnchor.BOTTOM,
-        description="Where to anchor subtitles relative to frame or content",
-    )
-    margin: float = Field(
-        0.1, description="Margin as fraction of frame height (0.0-0.5)"
-    )
-    content_aware: bool = Field(
-        True, description="Adjust position based on visual content bounds"
-    )
-
-    # Visual styling
-    style_preset: StylePreset = Field(
-        StylePreset.MODERN, description="Predefined style configuration"
-    )
-    font_size_scale: float = Field(
-        1.0, description="Scale factor for font size (0.5-2.0)"
-    )
-
-    # Text formatting
-    max_line_length: int = Field(38, description="Maximum characters per subtitle line")
-    max_words_per_line: int = Field(
-        3, description="Maximum words per subtitle line (0 to disable)"
-    )
-    max_subtitle_width_fraction: float = Field(
-        0.67,
-        description=(
-            "Maximum subtitle width as fraction of frame width (e.g. 0.67 = 2/3)"
-        ),
-    )
-    max_duration: float = Field(
-        4.5, description="Maximum duration for subtitle segments (seconds)"
-    )
-    min_duration: float = Field(
-        0.4, description="Minimum duration for subtitle segments (seconds)"
-    )
-
-    # Randomization system (REQUIREMENTS.md compliance)
-    randomize_fonts: bool = Field(
-        False, description="Enable random font selection from curated collection"
-    )
-    randomize_colors: bool = Field(
-        False, description="Use random coordinated color combinations"
-    )
-    randomize_effects: bool = Field(False, description="Use random animation effects")
-
-    # Manual overrides (optional)
-    selected_font: str | None = Field(
-        None, description="Override font selection (font family name)"
-    )
-    selected_color_pair: str | None = Field(
-        None, description="Override color pair selection"
-    )
-
-    # Platform safe zone (read from config.text_rendering.safe_zone, with
-    # optional per-profile overrides via subtitle_safe_zone_* fields)
-    safe_zone: PlatformSafeZone = Field(
-        default_factory=PlatformSafeZone,
-        description="Platform UI overlay avoidance boundaries",
-    )
-
-    # Advanced positioning (optional fine-tuning)
-    custom_position: Position | None = Field(
-        None, description="Custom position override (x,y as 0.0-1.0 fractions)"
-    )
-    horizontal_alignment: str = Field(
-        "center", description="Text alignment: left, center, right"
-    )
-
-
 def get_style_config(
     preset: StylePreset,
-    config: UnifiedSubtitleConfig | None = None,
+    config: SubtitleSettings | None = None,
     product_id: str | None = None,
     video_config: Any = None,
 ) -> dict[str, Any]:
@@ -266,7 +193,7 @@ def get_style_config(
 
 
 def calculate_position(
-    config: UnifiedSubtitleConfig,
+    config: SubtitleSettings,
     frame_size: tuple[int, int],
     visual_bounds: VisualBounds | None = None,
     safe_zone: PlatformSafeZone | None = None,
@@ -346,7 +273,7 @@ def calculate_position(
 
 
 def get_font_size(
-    config: UnifiedSubtitleConfig,
+    config: SubtitleSettings,
     frame_height: int,
     base_size_percent: float | None = None,
 ) -> int:
@@ -373,77 +300,3 @@ def get_font_size(
 
     # Ensure reasonable bounds from config
     return max(min_font, min(max_font, scaled_size))
-
-
-def create_unified_config_from_settings(
-    settings: dict[str, Any],
-) -> UnifiedSubtitleConfig:
-    """Create UnifiedSubtitleConfig from settings dictionary.
-
-    Args:
-    ----
-        settings: Dictionary containing subtitle configuration parameters
-
-    Returns:
-    -------
-        UnifiedSubtitleConfig instance with validated parameters
-
-    """
-    # DEBUG: Log all available keys and specific values
-    logger.debug(
-        f"create_unified_config_from_settings received keys: {settings.keys()}"
-    )
-    max_words = settings.get("max_words_per_line", "KEY_NOT_FOUND")
-    logger.debug(f"  max_words_per_line value: {max_words}")
-    logger.debug(f"  margin value: {settings.get('margin', 'KEY_NOT_FOUND')}")
-    logger.debug(f"  anchor value: {settings.get('anchor', 'KEY_NOT_FOUND')}")
-
-    # Extract anchor with validation
-    anchor_str = settings.get("anchor", "bottom")
-    try:
-        anchor = PositionAnchor(anchor_str)
-    except ValueError:
-        logger.warning(f"Invalid anchor '{anchor_str}', using 'bottom'")
-        anchor = PositionAnchor.BOTTOM
-
-    # Extract style preset with validation
-    preset_str = settings.get("style_preset", "modern")
-    try:
-        style_preset = StylePreset(preset_str)
-    except ValueError:
-        logger.warning(f"Invalid style_preset '{preset_str}', using 'modern'")
-        style_preset = StylePreset.MODERN
-
-    # Build safe zone from settings if present, otherwise use defaults
-    safe_zone_data = settings.get("safe_zone")
-    if isinstance(safe_zone_data, dict):
-        safe_zone = PlatformSafeZone(**safe_zone_data)
-    elif isinstance(safe_zone_data, PlatformSafeZone):
-        safe_zone = safe_zone_data
-    else:
-        safe_zone = PlatformSafeZone()
-
-    return UnifiedSubtitleConfig(
-        anchor=anchor,
-        content_aware=settings.get("content_aware", True),
-        style_preset=style_preset,
-        margin=settings.get("margin", 0.1),
-        font_size_scale=settings.get("font_size_scale", 1.0),
-        max_line_length=settings.get("max_line_length", 38),
-        max_words_per_line=settings.get("max_words_per_line", 3),
-        max_subtitle_width_fraction=settings.get("max_subtitle_width_fraction", 0.80),
-        max_duration=settings.get(
-            "max_duration", settings.get("max_subtitle_duration", 2.5)
-        ),
-        min_duration=settings.get(
-            "min_duration", settings.get("min_subtitle_duration", 0.6)
-        ),
-        randomize_fonts=settings.get("randomize_fonts", False),
-        randomize_colors=settings.get("randomize_colors", False),
-        randomize_effects=settings.get("randomize_effects", False),
-        selected_font=settings.get("selected_font"),
-        selected_color_pair=settings.get("selected_color_pair"),
-        custom_position=settings.get("custom_position"),
-        horizontal_alignment=settings.get("horizontal_alignment", "center"),
-        safe_zone=safe_zone,
-    )

--- a/src/video/subtitle_utils.py
+++ b/src/video/subtitle_utils.py
@@ -13,6 +13,7 @@ import pysrt
 
 from src.utils import ensure_dirs_exist
 from src.video.config import GoogleCloudSTTSettings, WhisperSettings
+from src.video.config.subtitle_models import SubtitleSettings
 from src.video.result_types import SubtitleResult
 from src.video.stt_functions import (
     GOOGLE_CLOUD_STT_AVAILABLE,
@@ -20,7 +21,6 @@ from src.video.stt_functions import (
     generate_subtitles_with_whisper,
     transcribe_with_google_cloud_stt,
 )
-from src.video.subtitle_positioning import create_unified_config_from_settings
 from src.video.unified_subtitle_generator import UnifiedSubtitleGenerator
 
 logger = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ def create_static_upper_subtitle(
         # font_size_scale, style_preset, randomize_effects) plus a private
         # key _upper_use_full_duration controlling CTA-only vs full display.
         use_full_duration = subtitle_settings.get("_upper_use_full_duration", False)
-        unified_config = create_unified_config_from_settings(subtitle_settings)
+        unified_config = SubtitleSettings.from_legacy_dict(subtitle_settings)
 
         # Get frame size from video config
         frame_size = (1080, 1920)  # Default
@@ -679,7 +679,7 @@ async def create_unified_subtitles(
         )
 
     # Create unified configuration from subtitle settings dict
-    unified_config = create_unified_config_from_settings(subtitle_settings)
+    unified_config = SubtitleSettings.from_legacy_dict(subtitle_settings)
 
     # Get frame size from video config
     frame_size = (1080, 1920)  # Default

--- a/src/video/unified_subtitle_generator.py
+++ b/src/video/unified_subtitle_generator.py
@@ -15,10 +15,10 @@ import pysrt
 
 from src.utils import ensure_dirs_exist
 from src.video.config import config
+from src.video.config.subtitle_models import SubtitleSettings
 from src.video.result_types import SubtitleResult
 from src.video.subtitle_positioning import (
     Position,
-    UnifiedSubtitleConfig,
     VisualBounds,
     calculate_position,
     get_font_size,
@@ -36,7 +36,7 @@ class UnifiedSubtitleGenerator:
 
     def __init__(
         self,
-        config: UnifiedSubtitleConfig,
+        config: SubtitleSettings,
         frame_size: tuple[int, int],
         product_id: str | None = None,
         video_config: Any = None,
@@ -45,7 +45,8 @@ class UnifiedSubtitleGenerator:
 
         Args:
         ----
-            config: Unified subtitle configuration
+            config: Unified SubtitleSettings used for positioning, text layout,
+                and randomization control.
             frame_size: Video frame dimensions (width, height)
             product_id: Product identifier for randomization seeding
             video_config: VideoConfig with validated style_presets

--- a/tests/test_profile_cli_overrides.py
+++ b/tests/test_profile_cli_overrides.py
@@ -37,7 +37,9 @@ class TestProfileSpecificSettings:
         assert profile.image_top_position_percent == 0.20
 
     def test_profile_subtitle_positioning_overrides(self, mock_config: VideoConfig):
-        """Test that profile can override subtitle positioning settings."""
+        """Test that profile can override subtitle positioning settings via the
+        nested subtitle_settings block (post-§4.3 shape).
+        """
         profile = VideoProfile(
             description="Test profile with subtitle positioning",
             use_scraped_images=True,
@@ -45,14 +47,41 @@ class TestProfileSpecificSettings:
             use_stock_images=False,
             use_stock_videos=False,
             use_dynamic_image_count=False,
-            subtitle_anchor="top",
-            subtitle_margin=0.15,
-            subtitle_content_aware=False,
+            subtitle_settings={
+                "anchor": "top",
+                "margin": 0.15,
+                "content_aware": False,
+            },
         )
 
-        assert profile.subtitle_anchor == "top"
-        assert profile.subtitle_margin == 0.15
-        assert profile.subtitle_content_aware is False
+        assert profile.subtitle_settings is not None
+        assert profile.subtitle_settings.anchor == "top"
+        assert profile.subtitle_settings.margin == 0.15
+        assert profile.subtitle_settings.content_aware is False
+
+    def test_profile_subtitle_legacy_flat_keys_migrate(self, mock_config: VideoConfig):
+        """Legacy flat subtitle_*/pycaps_*/two_part_subtitles keys load via
+        the deprecation shim and end up in the nested subtitle_settings.
+        """
+        with pytest.warns(DeprecationWarning, match="legacy flat subtitle"):
+            profile = VideoProfile(
+                description="Legacy-style profile",
+                use_scraped_images=True,
+                subtitle_anchor="top",
+                subtitle_margin=0.15,
+                subtitle_max_duration=3.0,
+                pycaps_template="hype",
+                pycaps_renderer="css",
+            )
+
+        assert profile.subtitle_settings is not None
+        assert profile.subtitle_settings.anchor == "top"
+        assert profile.subtitle_settings.margin == 0.15
+        assert profile.subtitle_settings.max_duration == 3.0
+        assert profile.subtitle_settings.pycaps == {
+            "template_name": "hype",
+            "renderer": "css",
+        }
 
     def test_profile_vertical_align_field(self):
         """Test video_vertical_align field on VideoProfile."""
@@ -194,12 +223,12 @@ class TestCollectOverrides:
             description="Remap test",
             use_scraped_images=True,
             use_scraped_videos=False,
-            subtitle_anchor="top",
+            video_vertical_align="center",
         )
-        field_map = {"subtitle_anchor": "anchor"}
+        field_map = {"video_vertical_align": "image_vertical_align"}
         result = VideoConfig._collect_overrides(profile, field_map)
 
-        assert result == {"anchor": "top"}
+        assert result == {"image_vertical_align": "center"}
 
 
 @pytest.mark.unit

--- a/tests/test_profile_cli_overrides.py
+++ b/tests/test_profile_cli_overrides.py
@@ -2,11 +2,15 @@
 
 import pytest
 
-from src.video.config import VideoConfig, VideoProfile, load_video_config
+from src.video.config import (
+    SubtitleSettings,
+    VideoConfig,
+    VideoProfile,
+    load_video_config,
+)
 from src.video.config.core_models import _deep_merge
 from src.video.config.visual_models import (
     MergedProfileSettings,
-    MergedSubtitleSettings,
     ProfileInfo,
     VideoSettings,
 )
@@ -79,7 +83,7 @@ class TestMergedProfileSettings:
 
         assert isinstance(merged, MergedProfileSettings)
         assert isinstance(merged.video_settings, VideoSettings)
-        assert isinstance(merged.subtitle_settings, MergedSubtitleSettings)
+        assert isinstance(merged.subtitle_settings, SubtitleSettings)
         assert isinstance(merged.profile, ProfileInfo)
 
     def test_profile_info_populated(self, mock_config: VideoConfig):

--- a/tests/test_unified_subtitle_generator.py
+++ b/tests/test_unified_subtitle_generator.py
@@ -6,10 +6,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from src.video.config.subtitle_models import SubtitleSettings
 from src.video.subtitle_positioning import (
     PositionAnchor,
     StylePreset,
-    UnifiedSubtitleConfig,
     VisualBounds,
 )
 from src.video.unified_subtitle_generator import UnifiedSubtitleGenerator
@@ -21,7 +21,7 @@ class TestUnifiedSubtitleGenerator:
     @pytest.fixture
     def sample_config(self):
         """Create a sample unified subtitle configuration."""
-        return UnifiedSubtitleConfig(
+        return SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
             margin=0.1,
             content_aware=False,
@@ -208,7 +208,7 @@ class TestUnifiedSubtitleGenerator:
             "font_width_to_height_ratio": 0.5,
         }
 
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
             margin=0.1,
             content_aware=False,
@@ -232,7 +232,7 @@ class TestUnifiedSubtitleGenerator:
         that overwrote RandomizationEngine colors with hardcoded black outlines.
         """
         # Create config with specific style colors
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
             margin=0.1,
             content_aware=False,
@@ -324,7 +324,7 @@ class TestUnifiedSubtitleGenerator:
 
     def test_word_count_limit(self):
         """Test subtitle segmentation with word count limit."""
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
             margin=0.1,
             content_aware=False,
@@ -348,7 +348,7 @@ class TestUnifiedSubtitleGenerator:
 
     def test_width_constraint(self):
         """Test subtitle width constraint based on frame width."""
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
             margin=0.1,
             content_aware=False,

--- a/tests/video/test_ass_effects.py
+++ b/tests/video/test_ass_effects.py
@@ -4,10 +4,10 @@ import re
 
 import pytest
 
+from src.video.config.subtitle_models import SubtitleSettings
 from src.video.subtitle_positioning import (
     Position,
     StylePreset,
-    UnifiedSubtitleConfig,
 )
 from src.video.unified_subtitle_generator import UnifiedSubtitleGenerator
 
@@ -15,7 +15,7 @@ from src.video.unified_subtitle_generator import UnifiedSubtitleGenerator
 @pytest.fixture
 def minimal_config():
     """Create a minimal preset config with no effects."""
-    return UnifiedSubtitleConfig(
+    return SubtitleSettings(
         style_preset=StylePreset.MINIMAL,
         anchor="bottom",
         margin=0.1,
@@ -29,7 +29,7 @@ def minimal_config():
 @pytest.fixture
 def animated_config():
     """Create an animated preset config with effects enabled."""
-    return UnifiedSubtitleConfig(
+    return SubtitleSettings(
         style_preset=StylePreset.ANIMATED,
         anchor="bottom",
         margin=0.1,
@@ -44,7 +44,7 @@ def animated_config():
 @pytest.fixture
 def random_config():
     """Create a random preset config for effect randomization."""
-    return UnifiedSubtitleConfig(
+    return SubtitleSettings(
         style_preset=StylePreset.RANDOM,
         anchor="bottom",
         margin=0.1,
@@ -59,7 +59,7 @@ def random_config():
 @pytest.fixture
 def modern_config():
     """Create a modern preset config with karaoke effect."""
-    return UnifiedSubtitleConfig(
+    return SubtitleSettings(
         style_preset=StylePreset.MODERN,
         anchor="bottom",
         margin=0.1,
@@ -73,7 +73,7 @@ def modern_config():
 @pytest.fixture
 def bold_config():
     """Create a bold preset config with fade effect."""
-    return UnifiedSubtitleConfig(
+    return SubtitleSettings(
         style_preset=StylePreset.BOLD,
         anchor="bottom",
         margin=0.1,

--- a/tests/video/test_pycaps_engine.py
+++ b/tests/video/test_pycaps_engine.py
@@ -14,8 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from src.video.config.subtitle_models import PycapsSettings
-from src.video.config.visual_models import MergedSubtitleSettings
+from src.video.config.subtitle_models import PycapsSettings, SubtitleSettings
 from src.video.pycaps_engine import (
     PycapsRenderer,
     PycapsRenderResult,
@@ -270,32 +269,32 @@ class TestMergeLayoutWithTemplate:
 
 
 class TestCreateUnifiedConfigDefaults:
-    """Verify the duration/width fallback chain in create_unified_config_from_settings
+    """Verify the duration/width fallback chain in SubtitleSettings.from_legacy_dict
     works correctly after the bug 3.1 fix.
     """
 
     def test_max_subtitle_duration_key_used_as_fallback(self):
-        from src.video.subtitle_positioning import create_unified_config_from_settings
+        from src.video.config.subtitle_models import SubtitleSettings
 
-        # MergedSubtitleSettings.model_dump() produces max_subtitle_duration, not max_duration
+        # SubtitleSettings.model_dump() produces max_subtitle_duration, not max_duration
         settings = {"max_subtitle_duration": 2.5, "min_subtitle_duration": 0.6}
-        config = create_unified_config_from_settings(settings)
+        config = SubtitleSettings.from_legacy_dict(settings)
         assert config.max_duration == 2.5
         assert config.min_duration == 0.6
 
     def test_max_duration_key_takes_priority(self):
-        from src.video.subtitle_positioning import create_unified_config_from_settings
+        from src.video.config.subtitle_models import SubtitleSettings
 
         settings = {"max_duration": 1.5, "max_subtitle_duration": 2.5}
-        config = create_unified_config_from_settings(settings)
+        config = SubtitleSettings.from_legacy_dict(settings)
         assert (
             config.max_duration == 1.5
         )  # max_duration wins over max_subtitle_duration
 
     def test_hardcoded_defaults_match_best_practices(self):
-        from src.video.subtitle_positioning import create_unified_config_from_settings
+        from src.video.config.subtitle_models import SubtitleSettings
 
-        config = create_unified_config_from_settings({})
+        config = SubtitleSettings.from_legacy_dict({})
         assert config.max_duration == 2.5  # best practice, was 4.5 before fix
         assert config.min_duration == 0.6  # best practice, was 0.4 before fix
         assert config.max_subtitle_width_fraction == 0.80  # was 0.67
@@ -306,12 +305,12 @@ class TestCreateUnifiedConfigDefaults:
         produces best-practice values for every profile.
         """
         import src.video.config as cfg_mod
-        from src.video.subtitle_positioning import create_unified_config_from_settings
+        from src.video.config.subtitle_models import SubtitleSettings
 
         cfg = cfg_mod.config
         for name in cfg.video_profiles:
             merged = cfg.get_profile_merged_settings(name)
-            uc = create_unified_config_from_settings(
+            uc = SubtitleSettings.from_legacy_dict(
                 merged.subtitle_settings.model_dump()
             )
             assert uc.max_duration == 2.5, f"{name}: max_duration={uc.max_duration}"
@@ -358,12 +357,12 @@ class TestConfigMergePycapsLayer:
         ]
 
     def test_default_engine_is_ffmpeg(self):
-        settings = MergedSubtitleSettings()
+        settings = SubtitleSettings()
         assert settings.subtitle_engine == "ffmpeg"
         assert settings.pycaps is None
 
     def test_pycaps_settings_in_dict_form_constructs_model(self):
-        settings = MergedSubtitleSettings(
+        settings = SubtitleSettings(
             subtitle_engine="pycaps",
             pycaps={"template_name": "vibrant", "renderer": "pictex"},
         )

--- a/tests/video/test_subtitle_positioning.py
+++ b/tests/video/test_subtitle_positioning.py
@@ -3,15 +3,13 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from src.video.config.core_models import PlatformSafeZone
+from src.video.config.subtitle_models import PlatformSafeZone, SubtitleSettings
 from src.video.subtitle_positioning import (
     PositionAnchor,
     StylePreset,
-    UnifiedSubtitleConfig,
     VisualBounds,
     calculate_position,
     clamp_to_safe_zone,
-    create_unified_config_from_settings,
     get_font_size,
     get_style_config,
 )
@@ -30,7 +28,7 @@ class TestSubtitlePositioning:
         ],
     )
     def test_calculate_position_basic_anchors(self, anchor, expected_y):
-        config = UnifiedSubtitleConfig(anchor=anchor, margin=0.1, content_aware=False)
+        config = SubtitleSettings(anchor=anchor, margin=0.1, content_aware=False)
         pos = calculate_position(config, (1080, 1920), safe_zone=self._wide_sz)
         assert pos.y == pytest.approx(expected_y)
         assert pos.x == 0.5
@@ -39,21 +37,21 @@ class TestSubtitlePositioning:
         """Verify safe zone clamps TOP and BOTTOM anchors."""
         sz = PlatformSafeZone()  # default cross-platform safe zone
         top = calculate_position(
-            UnifiedSubtitleConfig(anchor=PositionAnchor.TOP, margin=0.05),
+            SubtitleSettings(anchor=PositionAnchor.TOP, margin=0.05),
             (1080, 1920),
             safe_zone=sz,
         )
         assert top.y == pytest.approx(sz.min_y)  # margin < min_y, clamped
 
         bottom = calculate_position(
-            UnifiedSubtitleConfig(anchor=PositionAnchor.BOTTOM, margin=0.05),
+            SubtitleSettings(anchor=PositionAnchor.BOTTOM, margin=0.05),
             (1080, 1920),
             safe_zone=sz,
         )
         assert bottom.y == pytest.approx(sz.max_y)  # 0.95 > max_y, clamped
 
     def test_calculate_position_above_content(self):
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.ABOVE_CONTENT, margin=0.1, content_aware=True
         )
         visual_bounds = VisualBounds(x=0.1, y=0.2, width=0.8, height=0.6)
@@ -63,7 +61,7 @@ class TestSubtitlePositioning:
         assert pos.y == 0.1
 
     def test_calculate_position_below_content(self):
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BELOW_CONTENT, margin=0.05, content_aware=True
         )
         visual_bounds = VisualBounds(x=0.1, y=0.2, width=0.8, height=0.6)
@@ -74,7 +72,7 @@ class TestSubtitlePositioning:
 
     def test_calculate_position_below_content_clamped(self):
         sz = PlatformSafeZone(min_x=0.0, max_x=1.0, min_y=0.0, max_y=0.95)
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             anchor=PositionAnchor.BELOW_CONTENT, margin=0.2, content_aware=True
         )
         visual_bounds = VisualBounds(x=0.1, y=0.2, width=0.8, height=0.7)
@@ -90,20 +88,20 @@ class TestSubtitlePositioning:
         ],
     )
     def test_horizontal_alignment(self, alignment, expected_x):
-        config = UnifiedSubtitleConfig(horizontal_alignment=alignment)
+        config = SubtitleSettings(horizontal_alignment=alignment)
         pos = calculate_position(config, (1080, 1920), safe_zone=self._wide_sz)
         assert pos.x == pytest.approx(expected_x)
 
     def test_horizontal_alignment_clamped_to_safe_zone(self):
         sz = PlatformSafeZone()
         left = calculate_position(
-            UnifiedSubtitleConfig(horizontal_alignment="left"),
+            SubtitleSettings(horizontal_alignment="left"),
             (1080, 1920),
             safe_zone=sz,
         )
         assert left.x == pytest.approx(sz.min_x)
         right = calculate_position(
-            UnifiedSubtitleConfig(horizontal_alignment="right"),
+            SubtitleSettings(horizontal_alignment="right"),
             (1080, 1920),
             safe_zone=sz,
         )
@@ -122,7 +120,7 @@ class TestSubtitlePositioning:
         from src.video.subtitle_positioning import Position
 
         sz = PlatformSafeZone(min_x=0.1, max_x=0.9, min_y=0.1, max_y=0.9)
-        config = UnifiedSubtitleConfig(
+        config = SubtitleSettings(
             custom_position=Position(x=0.0, y=1.0),
         )
         pos = calculate_position(config, (1080, 1920), safe_zone=sz)
@@ -132,12 +130,12 @@ class TestSubtitlePositioning:
     def test_get_font_size(self):
         # Default base_font_size_percent is 0.04
         # 1000 * 0.04 = 40.
-        config = UnifiedSubtitleConfig(font_size_scale=1.0)
+        config = SubtitleSettings(font_size_scale=1.0)
         size = get_font_size(config, 1000, base_size_percent=0.04)
         assert size == 40
 
         # 40 * 2.0 = 80. (within default 100 max)
-        config_scaled = UnifiedSubtitleConfig(font_size_scale=2.0)
+        config_scaled = SubtitleSettings(font_size_scale=2.0)
         size_scaled = get_font_size(config_scaled, 1000, base_size_percent=0.04)
         assert size_scaled == 80
 
@@ -163,27 +161,31 @@ class TestSubtitlePositioning:
             assert style["font_name"] == "CustomFont"
 
     def test_get_style_config_random(self):
-        config = UnifiedSubtitleConfig(style_preset=StylePreset.RANDOM)
+        config = SubtitleSettings(style_preset=StylePreset.RANDOM)
         # Random preset forces randomization
         style = get_style_config(StylePreset.RANDOM, config, "prod123")
         assert len(style["effects"]) == 1
         assert config.randomize_fonts is True
 
-    def test_create_unified_config_from_settings(self):
+    def test_from_legacy_dict_basic(self):
         settings = {
             "anchor": "top",
             "margin": 0.15,
             "style_preset": "bold",
             "font_size_scale": 1.2,
         }
-        config = create_unified_config_from_settings(settings)
+        config = SubtitleSettings.from_legacy_dict(settings)
         assert config.anchor == PositionAnchor.TOP
         assert config.margin == 0.15
-        assert config.style_preset == "bold"
+        assert config.style_preset == StylePreset.BOLD
         assert config.font_size_scale == 1.2
 
-    def test_create_unified_config_invalid_values(self):
+    def test_from_legacy_dict_invalid_values_raise(self):
+        from pydantic import ValidationError
+
+        # Strict: invalid Literal/enum values must surface as ValidationError
+        # so callers can either fix the YAML or wrap in a fallback. The old
+        # wrapper silently fell back; that masked typos in production YAML.
         settings = {"anchor": "invalid", "style_preset": "garbage"}
-        config = create_unified_config_from_settings(settings)
-        assert config.anchor == PositionAnchor.BOTTOM  # Fallback
-        assert config.style_preset == "modern"  # Fallback
+        with pytest.raises(ValidationError):
+            SubtitleSettings.from_legacy_dict(settings)

--- a/tests/video/test_subtitle_settings_model.py
+++ b/tests/video/test_subtitle_settings_model.py
@@ -44,8 +44,8 @@ class TestSubtitleSettingsDefaults:
 
     def test_two_part_nested_default(self):
         s = SubtitleSettings()
-        assert isinstance(s.two_part, TwoPartSubtitleSettings)
-        assert s.two_part.enabled is False
+        assert isinstance(s.two_part_subtitles, TwoPartSubtitleSettings)
+        assert s.two_part_subtitles.enabled is False
 
 
 @pytest.mark.unit
@@ -72,7 +72,7 @@ class TestFromLegacyDict:
 
     def test_two_part_rename(self):
         s = SubtitleSettings.from_legacy_dict({"two_part_subtitles": {"enabled": True}})
-        assert s.two_part.enabled is True
+        assert s.two_part_subtitles.enabled is True
 
     def test_canonical_wins_over_legacy_when_both_present(self):
         s = SubtitleSettings.from_legacy_dict(
@@ -94,16 +94,18 @@ class TestFromLegacyDict:
         with pytest.raises(ValidationError):
             SubtitleSettings.from_legacy_dict({"not_a_real_field": "x"})
 
-    def test_merged_subtitle_settings_dump_round_trips(self):
-        """A dump from the existing MergedSubtitleSettings code path loads."""
-        from src.video.config.visual_models import MergedSubtitleSettings
-
-        merged = MergedSubtitleSettings()
-        dump = merged.model_dump()
-        s = SubtitleSettings.from_legacy_dict(dump)
-        # Canonical names won from the translation
-        assert isinstance(s.max_duration, float)
-        assert isinstance(s.min_duration, float)
+    def test_legacy_dump_with_old_field_names_round_trips(self):
+        """A dict with legacy field names loads via the rename translator."""
+        legacy_dump = {
+            "max_subtitle_duration": 4.5,
+            "min_subtitle_duration": 0.4,
+            "max_words_per_line": 3,
+            "available_fonts": ["Arial"],  # historical extra="allow" key, dropped
+        }
+        s = SubtitleSettings.from_legacy_dict(legacy_dump)
+        assert s.max_duration == 4.5
+        assert s.min_duration == 0.4
+        assert s.max_words_per_line == 3
 
 
 @pytest.mark.unit
@@ -168,13 +170,19 @@ class TestPartialSubtitleSettingsMergeInto:
     def test_two_part_nested_merge_preserves_unspecified(self):
         base = SubtitleSettings()
         partial = PartialSubtitleSettings(
-            two_part={"enabled": True, "upper_line": {"style_preset": "minimal"}}
+            two_part_subtitles={
+                "enabled": True,
+                "upper_line": {"style_preset": "minimal"},
+            }
         )
         merged = partial.merge_into(base)
-        assert merged.two_part.enabled is True
-        assert merged.two_part.upper_line.style_preset == "minimal"
+        assert merged.two_part_subtitles.enabled is True
+        assert merged.two_part_subtitles.upper_line.style_preset == "minimal"
         # Unspecified upper_line fields preserved from base default
-        assert merged.two_part.upper_line.source_field == "shortened_affiliate_link"
+        assert (
+            merged.two_part_subtitles.upper_line.source_field
+            == "shortened_affiliate_link"
+        )
 
     def test_safe_zone_nested_merge(self):
         base = SubtitleSettings()

--- a/tests/video/test_subtitle_settings_model.py
+++ b/tests/video/test_subtitle_settings_model.py
@@ -1,0 +1,200 @@
+"""Unit tests for the unified SubtitleSettings / PartialSubtitleSettings models."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.video.config import config as video_config
+from src.video.config.subtitle_models import (
+    PartialSubtitleSettings,
+    PlatformSafeZone,
+    Position,
+    PositionAnchor,
+    PycapsSettings,
+    StylePreset,
+    SubtitleSettings,
+    TwoPartSubtitleSettings,
+)
+
+
+@pytest.mark.unit
+class TestSubtitleSettingsDefaults:
+    """Defaults match the best-practice recipe from docs/subtitle-best-practices.md."""
+
+    def test_duration_defaults_match_recipe(self):
+        s = SubtitleSettings()
+        assert s.max_duration == 2.5
+        assert s.min_duration == 0.6
+
+    def test_text_formatting_defaults(self):
+        s = SubtitleSettings()
+        assert s.max_words_per_line == 3
+        assert s.max_subtitle_width_fraction == 0.80
+        assert s.max_line_length == 38
+
+    def test_positioning_defaults(self):
+        s = SubtitleSettings()
+        assert s.anchor is PositionAnchor.BOTTOM
+        assert s.style_preset is StylePreset.MODERN
+        assert s.horizontal_alignment == "center"
+
+    def test_safe_zone_nested_default(self):
+        s = SubtitleSettings()
+        assert isinstance(s.safe_zone, PlatformSafeZone)
+        assert s.safe_zone.max_y == 0.75  # TikTok overlay floor
+
+    def test_two_part_nested_default(self):
+        s = SubtitleSettings()
+        assert isinstance(s.two_part, TwoPartSubtitleSettings)
+        assert s.two_part.enabled is False
+
+
+@pytest.mark.unit
+class TestExtraForbidCatchesTypos:
+    def test_typo_in_top_level_field_rejected(self):
+        with pytest.raises(ValidationError, match="font_nam"):
+            SubtitleSettings(font_nam="Montserrat")
+
+    def test_typo_in_partial_override_rejected(self):
+        with pytest.raises(ValidationError):
+            PartialSubtitleSettings(max_duratio=5.0)
+
+
+@pytest.mark.unit
+class TestFromLegacyDict:
+    """from_legacy_dict translates renames and drops dead keys."""
+
+    def test_duration_renames(self):
+        s = SubtitleSettings.from_legacy_dict(
+            {"max_subtitle_duration": 3.0, "min_subtitle_duration": 0.5}
+        )
+        assert s.max_duration == 3.0
+        assert s.min_duration == 0.5
+
+    def test_two_part_rename(self):
+        s = SubtitleSettings.from_legacy_dict({"two_part_subtitles": {"enabled": True}})
+        assert s.two_part.enabled is True
+
+    def test_canonical_wins_over_legacy_when_both_present(self):
+        s = SubtitleSettings.from_legacy_dict(
+            {"max_duration": 2.0, "max_subtitle_duration": 99.0}
+        )
+        assert s.max_duration == 2.0
+
+    def test_dead_keys_dropped_silently(self):
+        s = SubtitleSettings.from_legacy_dict(
+            {
+                "available_fonts": ["Arial", "Inter"],
+                "available_color_combinations": [],
+                "margin": 0.15,
+            }
+        )
+        assert s.margin == 0.15
+
+    def test_unknown_key_still_raises(self):
+        with pytest.raises(ValidationError):
+            SubtitleSettings.from_legacy_dict({"not_a_real_field": "x"})
+
+    def test_merged_subtitle_settings_dump_round_trips(self):
+        """A dump from the existing MergedSubtitleSettings code path loads."""
+        from src.video.config.visual_models import MergedSubtitleSettings
+
+        merged = MergedSubtitleSettings()
+        dump = merged.model_dump()
+        s = SubtitleSettings.from_legacy_dict(dump)
+        # Canonical names won from the translation
+        assert isinstance(s.max_duration, float)
+        assert isinstance(s.min_duration, float)
+
+
+@pytest.mark.unit
+class TestAllNineProfilesLoad:
+    """Every shipped VideoProfile merges cleanly into SubtitleSettings."""
+
+    def test_all_profiles_load_via_from_legacy_dict(self):
+        issues: list[str] = []
+        for name in video_config.video_profiles:
+            merged = video_config.get_profile_merged_settings(name)
+            dump = merged.subtitle_settings.model_dump()
+            try:
+                s = SubtitleSettings.from_legacy_dict(dump)
+            except ValidationError as e:
+                issues.append(f"{name}: {e}")
+                continue
+            # Best-practice invariants from the §10 appendix one-liner
+            if s.max_duration != 2.5:
+                issues.append(f"{name}: max_duration={s.max_duration}")
+            if s.min_duration != 0.6:
+                issues.append(f"{name}: min_duration={s.min_duration}")
+            if s.max_subtitle_width_fraction < 0.75:
+                issues.append(f"{name}: width={s.max_subtitle_width_fraction}")
+            if s.max_words_per_line < 3:
+                issues.append(f"{name}: wpl={s.max_words_per_line}")
+        assert not issues, "Profile round-trip issues: " + " | ".join(issues)
+
+
+@pytest.mark.unit
+class TestPartialSubtitleSettingsMergeInto:
+    """merge_into applies only non-None fields; nested models deep-merge."""
+
+    def test_empty_partial_returns_base_unchanged(self):
+        base = SubtitleSettings(max_duration=2.5, max_words_per_line=3)
+        merged = PartialSubtitleSettings().merge_into(base)
+        assert merged.max_duration == 2.5
+        assert merged.max_words_per_line == 3
+
+    def test_single_scalar_override_wins(self):
+        base = SubtitleSettings(max_duration=2.5)
+        partial = PartialSubtitleSettings(max_duration=4.0)
+        merged = partial.merge_into(base)
+        assert merged.max_duration == 4.0
+
+    def test_enum_override_applies(self):
+        base = SubtitleSettings()
+        partial = PartialSubtitleSettings(style_preset=StylePreset.BOLD)
+        merged = partial.merge_into(base)
+        assert merged.style_preset is StylePreset.BOLD
+
+    def test_pycaps_nested_merge_preserves_unspecified(self):
+        base = SubtitleSettings(
+            pycaps=PycapsSettings(template_name="word-focus", renderer="css")
+        )
+        partial = PartialSubtitleSettings(pycaps={"template_name": "hype"})
+        merged = partial.merge_into(base)
+        assert merged.pycaps is not None
+        assert merged.pycaps.template_name == "hype"
+        # Renderer preserved from base
+        assert merged.pycaps.renderer == "css"
+
+    def test_two_part_nested_merge_preserves_unspecified(self):
+        base = SubtitleSettings()
+        partial = PartialSubtitleSettings(
+            two_part={"enabled": True, "upper_line": {"style_preset": "minimal"}}
+        )
+        merged = partial.merge_into(base)
+        assert merged.two_part.enabled is True
+        assert merged.two_part.upper_line.style_preset == "minimal"
+        # Unspecified upper_line fields preserved from base default
+        assert merged.two_part.upper_line.source_field == "shortened_affiliate_link"
+
+    def test_safe_zone_nested_merge(self):
+        base = SubtitleSettings()
+        partial = PartialSubtitleSettings(safe_zone={"max_y": 0.65})
+        merged = partial.merge_into(base)
+        assert merged.safe_zone.max_y == 0.65
+        # Unspecified coords preserved
+        assert merged.safe_zone.min_x == base.safe_zone.min_x
+
+    def test_custom_position_dict_builds_position_model(self):
+        base = SubtitleSettings()
+        partial = PartialSubtitleSettings(custom_position={"x": 0.5, "y": 0.7})
+        merged = partial.merge_into(base)
+        assert merged.custom_position == Position(x=0.5, y=0.7)
+
+    def test_chained_overrides_compose(self):
+        """Simulates global <- profile <- CLI precedence order."""
+        base = SubtitleSettings(max_duration=2.5, max_words_per_line=3)
+        profile = PartialSubtitleSettings(max_duration=3.0)
+        cli = PartialSubtitleSettings(max_words_per_line=5)
+        merged = cli.merge_into(profile.merge_into(base))
+        assert merged.max_duration == 3.0
+        assert merged.max_words_per_line == 5


### PR DESCRIPTION
## Summary

Merge the historical pair `MergedSubtitleSettings` (config-side, `extra="allow"`) and `UnifiedSubtitleConfig` (runtime-side, strict) into a single `SubtitleSettings` model. The dict round-trip translator that bridged them — and hid the silent-drop class of bugs — is gone. Profile overrides go through a single nested `subtitle_settings` block instead of 30+ flat fields. Canonical names (`max_duration`, `min_duration`) replace the legacy parallel names.

## Type of Change

- [x] Refactoring
- [x] Breaking change (public API surface — `MergedSubtitleSettings` and `UnifiedSubtitleConfig` symbols deleted; legacy flat profile keys load with a `DeprecationWarning` for one release)

## Changes Made

**Step 1 — define the unified model**
- `SubtitleSettings` (`extra="forbid"`) and `PartialSubtitleSettings` (all-optional, `merge_into()` deep-merge) added in `src/video/config/subtitle_models.py`
- `from_legacy_dict()` translates renames (`max_subtitle_duration` → `max_duration`, etc.) and drops dead `extra="allow"` keys plus underscore-prefixed runtime side-channel keys
- `PlatformSafeZone`, `PositionAnchor`, `StylePreset`, `Position` relocated to `subtitle_models.py`. Old import paths still work via re-exports.

**Steps 2–6 — port consumers and delete old shapes**
- `UnifiedSubtitleGenerator.__init__` accepts `SubtitleSettings`
- 8 `UnifiedSubtitleConfig(**dict)` sites in `subtitle_builder.py` swap to `SubtitleSettings.from_legacy_dict(dict)`
- `subtitle_utils.py` and `config_validator.py` use `from_legacy_dict` directly
- `MergedProfileSettings.subtitle_settings` field type → `SubtitleSettings`
- Deletes: `class MergedSubtitleSettings`, `class UnifiedSubtitleConfig`, `create_unified_config_from_settings`
- Adds `subtitle_similarity_threshold` and `timing_smoothing` as proper fields (used to ride through `extra="allow"` on `MergedSubtitleSettings`)

**Steps 7–8 — flip VideoProfile to nested overrides**
- `VideoProfile.subtitle_settings: PartialSubtitleSettings | None` replaces the 30+ flat `subtitle_*` / `pycaps_*` / `two_part_subtitles_*` / `subtitle_safe_zone_*` fields
- `_collect_overrides` field_map for subtitles, the per-profile safe_zone reassembly, and the pycaps/two_part folding logic in `get_profile_merged_settings` collapse to three lines (`partial.merge_into(base)`)
- `@model_validator(mode="before")` shim on `VideoProfile` migrates legacy flat keys to the nested block at load time, emitting a `DeprecationWarning` naming each key
- The shipped `config/video_production.yaml` profiles still use the legacy shape; their behaviour is unchanged because the shim handles them. YAML migration is a follow-up.

## Documentation

- `docs/requirements.md` updated for the nested override shape and strict validation behaviour
- `docs/configuration.md` per-profile subtitle override example rewritten around the nested block plus canonical field names
- `docs/troubleshooting.md` timing example uses canonical names
- `docs/pycaps-followups.md` `timing_smoothing` historical note refreshed (now a typed field)
- `CLAUDE.md` new Video Module notes for the unified model and nested-profile-override pattern
- `CHANGELOG.md` covers the breaking changes and the migration shim

## Testing

- [x] Full suite passes: 2097 passed, 56 skipped
- [x] `ruff check`, `ruff format --check`, and `mypy .` all clean
- [x] Internal best-practice verification one-liner passes for all 9 video profiles (max_duration=2.5, min_duration=0.6, width≥0.75, max_words_per_line≥3)
- [x] New `tests/video/test_subtitle_settings_model.py` covers defaults, `extra="forbid"` typo rejection, `from_legacy_dict` renames/drops, all-9-profile round-trip, `merge_into` for scalar / enum / nested (pycaps, two_part_subtitles, safe_zone) / chained CLI-style overrides
- [x] `tests/test_profile_cli_overrides.py` updated to use the nested form, plus a dedicated test for the deprecation shim

## Migration Notes

External profile YAML using the legacy flat shape (`subtitle_anchor`, `subtitle_max_duration`, `pycaps_template`, `two_part_subtitles`, ...) loads with a `DeprecationWarning` listing the migrated keys. Move them to:

```yaml
profiles:
  my_profile:
    subtitle_settings:
      anchor: top
      max_duration: 2.5
      pycaps:
        template_name: hype
      two_part_subtitles:
        enabled: true
```

External callers that imported `MergedSubtitleSettings` or `UnifiedSubtitleConfig` need to switch to `SubtitleSettings`. `create_unified_config_from_settings(d)` becomes `SubtitleSettings.from_legacy_dict(d)`.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] CHANGELOG.md updated
- [x] No new warnings introduced (the `DeprecationWarning` from the legacy shim is intentional)