### PR TITLE
Reduce pycaps template_pool to recipe-fit two-entry default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.1] - 2026-05-02
+
 ### Changed
 - Bundled pycaps `template_pool` reduced from `["word-focus", "neo-minimal", "minimalist", "explosive"]` to `["explosive", "word-focus"]`. Drops the two templates that fail multiple rules in `docs/subtitle-best-practices.md` (neo-minimal: monospace + code-editor block; minimalist: regular weight + translucent box, no stroke). Maintains 50/50 AI-tagged split since explosive ships an AI tagger rule and word-focus does not.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bundled pycaps `template_pool` reduced from `["word-focus", "neo-minimal", "minimalist", "explosive"]` to `["explosive", "word-focus"]`. Drops the two templates that fail multiple rules in `docs/subtitle-best-practices.md` (neo-minimal: monospace + code-editor block; minimalist: regular weight + translucent box, no stroke). Maintains 50/50 AI-tagged split since explosive ships an AI tagger rule and word-focus does not.
+
 ## [0.44.0] - 2026-05-02
 
 ### Added

--- a/config/subtitles.yaml
+++ b/config/subtitles.yaml
@@ -60,13 +60,16 @@ subtitle_settings:
     template_name: "explosive"
 
     # Pool for deterministic per-product template selection (md5 keyed).
-    # 50/50 mix of AI-tagged and untagged templates so AI word tagging
-    # fires on roughly half the videos when enable_ai_tagging is true:
-    #   word-focus  = closest match to the best-practice recipe (no AI rule)
-    #   neo-minimal = AI rule highlights "most relevant impactful phrase"
-    #   minimalist  = calmer tone for educational/corporate (no AI rule)
-    #   explosive   = AI rule scale-pops "most important word in script"
-    template_pool: ["word-focus", "neo-minimal", "minimalist", "explosive"]
+    # Two-entry recipe-fit pool: each template passes most rules in
+    # docs/subtitle-best-practices.md (1 typography, 3 stroke + shadow,
+    # 4 karaoke, 5 word count, 13 contrast). neo-minimal and minimalist
+    # were dropped because they fail rules 1 + 3 (monospace / regular
+    # weight, no stroke).
+    #   explosive  = AI rule scale-pops "most important word in script"
+    #   word-focus = white + thick stroke, no AI rule
+    # Maintains 50/50 AI-tagged split (1 of 2 templates has an AI rule)
+    # while every roll lands on a recipe-fit template.
+    template_pool: ["explosive", "word-focus"]
 
     # css = Playwright + Chromium. Full CSS fidelity, ~400 MB peak RSS,
     #       ~0.7x realtime on a 30s clip. Benchmark winner.
@@ -85,9 +88,13 @@ subtitle_settings:
     max_number_of_lines: 2
 
     # Vertical positioning. "bottom" anchor + offset -0.20 places captions
-    # at ~75% of frame height, matching the platform safe zone bottom
-    # boundary (TikTok overlay starts at 75%). Tweak the offset to move
-    # captions up (more negative) or down (closer to 0).
+    # at ~75% of frame height. This sits inside TikTok's bottom UI overlay
+    # zone, but every bundled profile here uses `image_vertical_align:
+    # center` (slideshow_*) or full-frame source video (product_video_*),
+    # so a recipe-aligned vertical-center caption position (~55%) collides
+    # with product imagery. Lower-third is the lesser evil until profiles
+    # adopt `image_vertical_align: top` (then captions can rise to ~55%
+    # safely). Tracked in #99.
     vertical_align: "bottom"
     vertical_align_offset: -0.20
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ field default (used when constructing without YAML) is `ffmpeg`.
 subtitle_settings:
   subtitle_engine: "pycaps"
   pycaps:
-    template_pool: ["word-focus", "neo-minimal", "minimalist", "explosive"]
+    template_pool: ["explosive", "word-focus"]
     renderer: "css"
     fallback_policy: "fallback_ffmpeg"  # forks without --with pycaps land here
 ```

--- a/docs/pycaps-subtitles.md
+++ b/docs/pycaps-subtitles.md
@@ -83,10 +83,15 @@ All fields live under `subtitle_settings.pycaps` (YAML + merged runtime).
 Per-profile overrides use a flat prefix (`pycaps_template`, `pycaps_renderer`,
 etc.) to mirror the other profile override naming.
 
+The "Default" column lists the `PycapsSettings` Pydantic field defaults
+(used for programmatic construction without YAML). The bundled
+`config/subtitles.yaml` overrides several of them — see the inline
+comments in that file for the active values shipped to users.
+
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `template_name` | str | `word-focus` | Fixed template name. Used when `template_pool` is empty or single-entry. |
-| `template_pool` | list[str] | `[word-focus, hype, minimalist, vibrant]` | Pool for deterministic per-product selection (md5 hash of product_id). |
+| `template_name` | str | `explosive` | Fixed template name. Used when `template_pool` is empty or single-entry, which is also what `--pycaps-template NAME` triggers (the flag clears the pool). |
+| `template_pool` | list[str] | `[word-focus, hype, minimalist, vibrant]` | Pool for deterministic per-product selection (md5 hash of product_id). Bundled YAML ships a 2-entry recipe-fit override. |
 | `renderer` | `css` \| `pictex` | `css` | `css` = Playwright + Chromium. `pictex` = browserless Skia path. |
 | `max_width_ratio` | float | 0.85 | Max caption width as a fraction of frame width. |
 | `max_number_of_lines` | int | 2 | Max lines per caption segment. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.44.0"
+version = "0.44.1"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- Keep total ≤40 lines. Plain English, neutral tone. No marketing words, no closing summary, no em dashes. -->

## Summary

Refs #100 (first acceptance criterion). Refs #99. Reduces the bundled pycaps `template_pool` in `config/subtitles.yaml` from four entries to two recipe-fit entries, and rewrites the `vertical_align_offset` YAML comment to record why the offset stays at `-0.20` (recipe rule 8 assumes `image_vertical_align: top`, which none of the bundled profiles use).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor
- [ ] Performance
- [ ] Tests

## Changes

- `template_pool: ["word-focus", "neo-minimal", "minimalist", "explosive"] → ["explosive", "word-focus"]`. Drops the two templates that fail rules 1 + 3 of `docs/subtitle-best-practices.md` (neo-minimal: Consolas monospace + code-editor block; minimalist: regular weight + translucent box, no stroke). 50/50 AI-tagged split preserved (explosive has an AI rule, word-focus does not).
- YAML comment on `vertical_align_offset` now records the constraint that prevents the recipe-aligned ~55% caption position from working with the bundled profiles: every profile here either centers the product image (`slideshow_*`) or fills the frame with source video (`product_video_*`), so vertical-center captions collide with product imagery. The `-0.20` lower-third position is the working compromise. Full fix tracked in #99.

## Testing

- [x] Existing tests pass (YAML-only change)
- [x] Manual check: visual smoke on `B0DS2B3P2B / product_video_sequential` confirmed the pool selection lands on a recipe-fit template (`word-focus` for that ASIN's md5 roll) and that `-0.20` keeps captions clear of product imagery.

## Checklist

- [x] `make lint` passes (no Python changes)
- [x] Docs updated (CHANGELOG)
- [x] CHANGELOG.md updated
- [x] No new warnings

## Deployment notes

None. Forks that prefer the prior 4-entry pool can override `subtitle_settings.pycaps.template_pool` in YAML.