### PR TITLE
Drop YAML re-read fallback in get_style_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.2] - 2026-05-02
+
 ### Removed
 - **Breaking** (internal API): `get_style_config` in `src/video/subtitle_positioning.py` now requires `video_config` and raises `ValueError` when it's missing or unusable. The legacy YAML re-read fallback (`Path("config/subtitles.yaml")` + `yaml.safe_load`) and the inline hardcoded modern-defaults dict are gone. The old fallbacks were CWD-dependent, bypassed CLI overrides, silently dropped YAML typos, and drifted from the typed Pydantic defaults; all four production call sites already passed `video_config`. Test fixtures that constructed `UnifiedSubtitleGenerator` without `video_config` now use the conftest `mock_config` (real `VideoConfig` with default `style_presets`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Breaking** (internal API): `get_style_config` in `src/video/subtitle_positioning.py` now requires `video_config` and raises `ValueError` when it's missing or unusable. The legacy YAML re-read fallback (`Path("config/subtitles.yaml")` + `yaml.safe_load`) and the inline hardcoded modern-defaults dict are gone. The old fallbacks were CWD-dependent, bypassed CLI overrides, silently dropped YAML typos, and drifted from the typed Pydantic defaults; all four production call sites already passed `video_config`. Test fixtures that constructed `UnifiedSubtitleGenerator` without `video_config` now use the conftest `mock_config` (real `VideoConfig` with default `style_presets`).
+
 ## [0.44.1] - 2026-05-02
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.44.1"
+version = "0.44.2"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/video/subtitle_positioning.py
+++ b/src/video/subtitle_positioning.py
@@ -64,66 +64,65 @@ def get_style_config(
 ) -> dict[str, Any]:
     """Get style configuration for a given preset with optional randomization.
 
+    Reads the style preset from `video_config.style_presets` (the typed
+    Pydantic source of truth). The legacy YAML re-read fallback was removed
+    because it was CWD-dependent (`Path("config/subtitles.yaml")`), bypassed
+    CLI overrides (fresh re-read on every call skipped the 3-level merge),
+    and silently dropped YAML typos (no validation). Callers must pass
+    `video_config` explicitly.
+
     Args:
     ----
         preset: Base style preset to use
         config: Unified subtitle configuration with randomization settings
         product_id: Product identifier for consistent randomization seeding
-        video_config: VideoConfig with validated style_presets (preferred path)
+        video_config: VideoConfig with validated style_presets (required)
 
     Returns:
     -------
         Dictionary of style parameters for subtitle generation
 
+    Raises:
+    ------
+        ValueError: video_config is None, video_config.style_presets is
+            missing or not a dict, or no preset matches `preset` and no
+            `modern` fallback exists in style_presets.
+        TypeError: video_config.style_presets[preset] is not a Pydantic
+            model (i.e. doesn't expose `.model_dump()`).
+
     """
     preset_key = preset.value if isinstance(preset, StylePreset) else preset
 
-    base_config: dict[str, Any] | None = None
+    if video_config is None:
+        raise ValueError(
+            "get_style_config requires video_config (a VideoConfig with "
+            "style_presets). The legacy YAML re-read fallback was removed; "
+            "pass video_config explicitly."
+        )
 
-    # Preferred path: typed config, no YAML re-read, no CWD dependency.
-    if video_config is not None:
-        presets = getattr(video_config, "style_presets", None)
-        if isinstance(presets, dict):
-            preset_obj = presets.get(preset_key) or presets.get("modern")
-            if preset_obj is not None and hasattr(preset_obj, "model_dump"):
-                base_config = preset_obj.model_dump(exclude={"description"})
+    presets = getattr(video_config, "style_presets", None)
+    if not isinstance(presets, dict):
+        raise ValueError(
+            f"video_config.style_presets is missing or invalid (got "
+            f"{type(presets).__name__}). Cannot resolve style preset "
+            f"{preset_key!r}."
+        )
 
-    # Legacy path: re-read YAML for callers that don't have VideoConfig yet.
-    if base_config is None:
-        from pathlib import Path
+    preset_obj = presets.get(preset_key) or presets.get("modern")
+    if preset_obj is None:
+        raise ValueError(
+            f"No style preset matches {preset_key!r} and no 'modern' "
+            f"fallback in video_config.style_presets. Available: "
+            f"{sorted(presets.keys())}."
+        )
 
-        import yaml
+    if not hasattr(preset_obj, "model_dump"):
+        raise TypeError(
+            f"video_config.style_presets[{preset_key!r}] is not a Pydantic "
+            f"model (got {type(preset_obj).__name__})."
+        )
 
-        subtitles_config_path = Path("config/subtitles.yaml")
-        style_presets: dict[str, Any] = {}
-        try:
-            if subtitles_config_path.exists():
-                with open(subtitles_config_path, encoding="utf-8") as f:
-                    subtitles_data = yaml.safe_load(f)
-                    style_presets = subtitles_data.get("style_presets", {})
-        except Exception as e:
-            logger.warning("Could not load style presets from config: %s", e)
-
-        if preset_key in style_presets:
-            base_config = style_presets[preset_key].copy()
-            base_config.pop("description", None)
-        elif "modern" in style_presets:
-            base_config = style_presets["modern"].copy()
-            base_config.pop("description", None)
-
-    # Absolute last resort: inline modern defaults.
-    if base_config is None:
-        base_config = {
-            "font_name": "Montserrat",
-            "font_color": "&H00FFFFFF",
-            "outline_color": "&H00000000",
-            "background_color": None,
-            "bold": True,
-            "outline_thickness": 3,
-            "shadow": True,
-            "effects": ["karaoke"],
-            "font_width_to_height_ratio": 0.5,
-        }
+    base_config = preset_obj.model_dump(exclude={"description"})
 
     # Handle RANDOM preset - force randomization and select one random effect
     if preset == StylePreset.RANDOM and product_id:

--- a/tests/test_two_part_subtitles.py
+++ b/tests/test_two_part_subtitles.py
@@ -2,7 +2,6 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -15,12 +14,14 @@ class TestTwoPartSubtitles:
     """Test suite for two-part subtitle system."""
 
     @pytest.fixture
-    def mock_video_config(self):
-        """Create mock video configuration."""
-        config = Mock()
-        config.video_settings = Mock()
-        config.video_settings.resolution = (1080, 1920)  # Portrait orientation
-        return config
+    def mock_video_config(self, mock_config):
+        """Use the project's `mock_config` from conftest.
+
+        Past iterations used a bare `Mock()`, but `get_style_config` now
+        requires a real `VideoConfig` with `style_presets` populated. The
+        20 usages of this fixture still pick the same name without churn.
+        """
+        return mock_config
 
     @pytest.fixture
     def basic_subtitle_settings(self):

--- a/tests/test_unified_subtitle_generator.py
+++ b/tests/test_unified_subtitle_generator.py
@@ -36,10 +36,12 @@ class TestUnifiedSubtitleGenerator:
         )
 
     @pytest.fixture
-    def generator(self, sample_config):
+    def generator(self, sample_config, mock_config):
         """Create a UnifiedSubtitleGenerator instance."""
         frame_size = (1920, 1080)
-        return UnifiedSubtitleGenerator(sample_config, frame_size)
+        return UnifiedSubtitleGenerator(
+            sample_config, frame_size, video_config=mock_config
+        )
 
     @pytest.fixture
     def sample_timings(self):
@@ -50,10 +52,12 @@ class TestUnifiedSubtitleGenerator:
             {"word": "test", "start_time": 1.1, "end_time": 1.5},
         ]
 
-    def test_init(self, sample_config):
+    def test_init(self, sample_config, mock_config):
         """Test UnifiedSubtitleGenerator initialization."""
         frame_size = (1920, 1080)
-        generator = UnifiedSubtitleGenerator(sample_config, frame_size)
+        generator = UnifiedSubtitleGenerator(
+            sample_config, frame_size, video_config=mock_config
+        )
 
         assert generator.config == sample_config
         assert generator.frame_size == frame_size
@@ -179,10 +183,12 @@ class TestUnifiedSubtitleGenerator:
             assert "[V4+ Styles]" in content
             assert "[Events]" in content
 
-    def test_color_selection_consistency(self, sample_config):
+    def test_color_selection_consistency(self, sample_config, mock_config):
         """Test that colors are selected consistently per instance."""
         frame_size = (1920, 1080)
-        generator = UnifiedSubtitleGenerator(sample_config, frame_size)
+        generator = UnifiedSubtitleGenerator(
+            sample_config, frame_size, video_config=mock_config
+        )
 
         colors1 = generator._get_colors()
         colors2 = generator._get_colors()
@@ -225,7 +231,7 @@ class TestUnifiedSubtitleGenerator:
         assert colors["outline"] == "&H00008000"  # Dark green
         # NOT black (&H00000000) from old legacy randomization
 
-    def test_select_colors_preserves_style_config(self):
+    def test_select_colors_preserves_style_config(self, mock_config):
         """Test that _select_colors() uses colors from style_config without overwriting.
 
         Regression test for bug where _select_colors() had legacy randomization
@@ -241,7 +247,9 @@ class TestUnifiedSubtitleGenerator:
         )
         frame_size = (1920, 1080)
 
-        generator = UnifiedSubtitleGenerator(config, frame_size)
+        generator = UnifiedSubtitleGenerator(
+            config, frame_size, video_config=mock_config
+        )
 
         # _select_colors() should return colors from style_config
         # The BOLD preset has specific outline color
@@ -322,7 +330,7 @@ class TestUnifiedSubtitleGenerator:
 
             assert result.success is True
 
-    def test_word_count_limit(self):
+    def test_word_count_limit(self, mock_config):
         """Test subtitle segmentation with word count limit."""
         config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
@@ -333,7 +341,9 @@ class TestUnifiedSubtitleGenerator:
             max_words_per_line=3,  # Strict word limit
             max_subtitle_width_fraction=0.67,
         )
-        generator = UnifiedSubtitleGenerator(config, (1920, 1080))
+        generator = UnifiedSubtitleGenerator(
+            config, (1920, 1080), video_config=mock_config
+        )
 
         # Script with multiple words
         script_text = "This is a long sentence with many words in it"
@@ -346,7 +356,7 @@ class TestUnifiedSubtitleGenerator:
             word_count = len(seg["text"].split())
             assert word_count <= 3, f"Segment has {word_count} words: {seg['text']}"
 
-    def test_width_constraint(self):
+    def test_width_constraint(self, mock_config):
         """Test subtitle width constraint based on frame width."""
         config = SubtitleSettings(
             anchor=PositionAnchor.BOTTOM,
@@ -358,7 +368,9 @@ class TestUnifiedSubtitleGenerator:
             max_subtitle_width_fraction=0.67,  # 2/3 of frame
         )
         frame_size = (1080, 1920)  # Width, Height
-        generator = UnifiedSubtitleGenerator(config, frame_size)
+        generator = UnifiedSubtitleGenerator(
+            config, frame_size, video_config=mock_config
+        )
 
         # Test that width calculation uses frame-based constraint
         max_width = int(frame_size[0] * 0.67)

--- a/tests/video/test_ass_effects.py
+++ b/tests/video/test_ass_effects.py
@@ -100,6 +100,25 @@ def sample_segments():
     ]
 
 
+@pytest.fixture(autouse=True)
+def _default_video_config(monkeypatch, mock_config):
+    """Inject `mock_config` as `video_config` when tests construct a
+    `UnifiedSubtitleGenerator` without one.
+
+    Production callers always pass `video_config`. The tests in this file
+    predate the change in `get_style_config` that made `video_config`
+    required. Patching the constructor here avoids touching ~25 call sites
+    individually.
+    """
+    original_init = UnifiedSubtitleGenerator.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs.setdefault("video_config", mock_config)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(UnifiedSubtitleGenerator, "__init__", _patched_init)
+
+
 class TestASSEffectSelection:
     """Tests for effect selection logic."""
 

--- a/tests/video/test_subtitle_positioning.py
+++ b/tests/video/test_subtitle_positioning.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -139,31 +138,33 @@ class TestSubtitlePositioning:
         size_scaled = get_font_size(config_scaled, 1000, base_size_percent=0.04)
         assert size_scaled == 80
 
-    def test_get_style_config_fallback(self):
-        # Test fallback when yaml missing and no video_config
-        with patch("pathlib.Path.exists", return_value=False):
-            style = get_style_config(StylePreset.MINIMAL)
-            # Inline last-resort defaults use Montserrat (modern preset)
-            assert style["font_name"] == "Montserrat"
+    def test_get_style_config_raises_without_video_config(self):
+        # The legacy YAML re-read fallback was removed; callers must pass
+        # video_config so the typed style_presets path is taken.
+        with pytest.raises(ValueError, match="requires video_config"):
+            get_style_config(StylePreset.MINIMAL)
 
-            style_modern = get_style_config(StylePreset.MODERN)
-            assert "karaoke" in style_modern["effects"]
+    def test_get_style_config_raises_when_preset_missing(self, mock_config):
+        # If neither the requested preset nor "modern" exists in
+        # style_presets, the function raises with a clear message.
+        mock_config.style_presets = {}
+        with pytest.raises(ValueError, match="No style preset matches"):
+            get_style_config(StylePreset.MINIMAL, video_config=mock_config)
 
-    def test_get_style_config_yaml(self):
-        mock_yaml = (
-            "style_presets:\n  minimal:\n    font_name: 'CustomFont'\n    effects: []"
-        )
-        with (
-            patch("pathlib.Path.exists", return_value=True),
-            patch("builtins.open", mock_open(read_data=mock_yaml)),
-        ):
-            style = get_style_config(StylePreset.MINIMAL)
-            assert style["font_name"] == "CustomFont"
+    def test_get_style_config_uses_typed_presets(self, mock_config):
+        # Default VideoConfig ships 5 presets (minimal, modern, bold,
+        # animated, random); the typed path returns the requested one.
+        style = get_style_config(StylePreset.MINIMAL, video_config=mock_config)
+        assert "font_name" in style
+        assert "effects" in style
 
-    def test_get_style_config_random(self):
+    def test_get_style_config_random(self, mock_config):
         config = SubtitleSettings(style_preset=StylePreset.RANDOM)
-        # Random preset forces randomization
-        style = get_style_config(StylePreset.RANDOM, config, "prod123")
+        # RANDOM preset forces randomization and selects one effect from the
+        # preset's effects list.
+        style = get_style_config(
+            StylePreset.RANDOM, config, "prod123", video_config=mock_config
+        )
         assert len(style["effects"]) == 1
         assert config.randomize_fonts is True
 


### PR DESCRIPTION
<!-- Keep total ≤40 lines. Plain English, neutral tone. No marketing words, no closing summary, no em dashes. -->

## Summary

Closes #94. `get_style_config` in `src/video/subtitle_positioning.py` now requires `video_config` and raises `ValueError` when it's missing or unusable. Drops the legacy YAML re-read fallback (`Path("config/subtitles.yaml")` + `yaml.safe_load`) and the inline hardcoded modern-defaults dict.

## Type of change

- [x] Bug fix
- [x] Refactor
- [x] Breaking change (internal API; flagged in CHANGELOG. No user-facing CLI/YAML behavior changes.)
- [ ] New feature
- [ ] Documentation
- [ ] Performance
- [x] Tests

## Changes

- **`src/video/subtitle_positioning.py::get_style_config`**: only path now is `video_config.style_presets`. Raises `ValueError` when `video_config` is `None`, when `style_presets` is missing or not a dict, or when no preset matches the requested key and no `modern` fallback exists. Raises `TypeError` when a preset entry isn't a Pydantic model. Docstring rewritten to document both the new contract and the removal rationale.
- **All 4 production call sites already pass `video_config`** (`unified_subtitle_generator.py:58`, `assembler/subtitle_builder.py:181/344/493`); no production behavior change.
- **`tests/video/test_subtitle_positioning.py`**: dropped the obsolete `test_get_style_config_yaml` (no YAML re-read to test). Added `test_get_style_config_raises_without_video_config` and `test_get_style_config_raises_when_preset_missing`. Rewrote `test_get_style_config_random` to pass the conftest `mock_config`.
- **`tests/test_unified_subtitle_generator.py`**: 1 fixture and 5 test methods now pass `mock_config` as `video_config`.
- **`tests/test_two_part_subtitles.py`**: replaced the local `Mock()` video_config (which was silently relying on the YAML re-read fallback) with the conftest `mock_config` real `VideoConfig`. Removed the now-unused `unittest.mock` import.
- **`tests/video/test_ass_effects.py`**: added an autouse fixture that injects `mock_config` as `video_config` for all 25 constructor call sites in the file. Avoids touching each individually.

## Why

The deleted fallbacks killed four latent bugs:
- CWD-dependent `Path("config/subtitles.yaml")` fails from any process outside the project root
- Bypassed the 3-level CLI override merge (preset block was fresh-re-read on every call)
- Silent typo failure (`font_nam: Montserrat` was dropped without warning)
- Drift between the YAML re-read result and typed Pydantic defaults

## Testing

- [x] `make lint` passes (`ruff check`, `ruff format --check`, `mypy .`)
- [x] `pytest --cov=src` 2163 passed, 56 skipped, coverage 58.27%
- [x] All 4 production call sites already passed `video_config`; no production code changed
- [x] Test fixtures audited so the typed path is exercised everywhere

## Checklist

- [x] `make lint` passes
- [x] Docs updated (CHANGELOG)
- [x] CHANGELOG.md updated
- [x] No new warnings

## Deployment notes

Internal API change only. No user-facing CLI/YAML behavior changes. Forks that built their own callers of `get_style_config` need to pass `video_config`; the new error message points them at the fix.