### PR TITLE
Docs: 2026 safe-zone alignment, audio + cut-cadence, engagement/conversion roadmap items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ ROADMAP.private.md
 # runtime-only and never go in git.
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+# Playwright MCP runtime captures (page snapshots, console logs). Capture
+# logged-in session state, so they must never be committed.
+.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- `docs/platform-safe-zones.md` is now the canonical safe-zone reference, refreshed to 2026 platform specs (Meta's unified Reels/Stories margins and TikTok's playlist button). The subtitle and promotional best-practices docs cite it instead of carrying their own divergent numbers.
+- New `docs/audio-best-practices.md` covers the sound-on layer: trending vs original audio, voiceover/music mix levels, ducking, the audio hook, and platform loudness.
+- New cut-cadence section in `docs/promotional-video-best-practices.md` (shot-length bands, transition vocabulary).
+
 ## [0.51.1] - 2026-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.2] - 2026-05-31
+
 ### Documentation
 - `docs/platform-safe-zones.md` is now the canonical safe-zone reference, refreshed to 2026 platform specs (Meta's unified Reels/Stories margins and TikTok's playlist button). The subtitle and promotional best-practices docs cite it instead of carrying their own divergent numbers.
 - New `docs/audio-best-practices.md` covers the sound-on layer: trending vs original audio, voiceover/music mix levels, ducking, the audio hook, and platform loudness.
 - New cut-cadence section in `docs/promotional-video-best-practices.md` (shot-length bands, transition vocabulary).
+- Roadmap gains a safe-zone constant follow-up plus five engagement/conversion items (hook-variant A/B measurement, loop-friendly ending, pre-production conversion gate, cover-frame generation, episodic series framing).
 
 ## [0.51.1] - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ See [Installation](docs/installation.md) for complete setup instructions.
 | [Linting](docs/linting.md) | Code quality tools (Ruff, MyPy, Bandit) |
 | [Requirements](docs/requirements.md) | Project requirements and specs |
 | [Subtitle Best Practices](docs/subtitle-best-practices.md) | Caption design research for TikTok/Shorts/Reels |
-| [Promotional Video Best Practices](docs/promotional-video-best-practices.md) | Hook, CTA, FTC disclosure, trust signals (engine-agnostic) |
+| [Promotional Video Best Practices](docs/promotional-video-best-practices.md) | Hook, cut cadence, CTA, FTC disclosure, trust signals (engine-agnostic) |
+| [Audio Best Practices](docs/audio-best-practices.md) | Trending vs original audio, voiceover/music levels, ducking |
 | [Versioning](docs/versioning.md) | Semantic versioning and releases |
 | [Contributing](CONTRIBUTING.md) | How to contribute |
 

--- a/docs/audio-best-practices.md
+++ b/docs/audio-best-practices.md
@@ -1,0 +1,136 @@
+# Audio Best Practices
+
+The sound-on layer for short-form vertical promotional video. The
+[promotional-video-best-practices.md](promotional-video-best-practices.md)
+doc treats sound-off as the primary audience (85% of views); this doc covers
+the other 15% and the parts of the audio track the algorithm reads even when
+the viewer has the sound off.
+
+**Audience**: 30-60 second 9:16 vertical product videos for TikTok, Instagram
+Reels, and YouTube Shorts.
+
+**Related docs**:
+- [promotional-video-best-practices.md](promotional-video-best-practices.md)
+  -- promo strategy; treats captions as the primary channel for the sound-off
+  majority.
+- [subtitle-best-practices.md](subtitle-best-practices.md) -- caption design,
+  including the timing smoother that leads the audio.
+- [tts-voice-profiles.md](tts-voice-profiles.md) -- TTS voice selection and the
+  voice-profile config.
+
+---
+
+## The rules that matter (cheat-sheet)
+
+1. **Audio is a search signal even on mute.** TikTok 2026 transcribes the
+   spoken track via ASR and indexes the transcript. The hook keyword must land
+   in the first 5 s of spoken audio, not just on-screen.
+2. **Voiceover sits at -3 to -6 dB peak (~-14 LUFS integrated).** Clear,
+   foreground, never fighting the music.
+3. **Music ducks 18-24 dB under the voice.** Background music sits around
+   -25 to -30 dB while narration plays; it can rise to -6 to -10 dB in
+   voice-free beats (intro sting, outro).
+4. **Lead with an audio hook in the first 3 seconds.** A beat drop, a spoken
+   punchline, or a recognizable sound, aligned with the visual hook.
+5. **Original audio over borrowed trending sound for product video.** A clear
+   product voiceover beats a trending song the viewer can't act on. Trending
+   sound helps discovery only inside its first 3-7 day window and rarely fits a
+   narration-led review.
+6. **Normalize to each platform's loudness target** so the video isn't
+   auto-attenuated louder or quieter than the feed around it.
+
+---
+
+## 1. Audio as a ranking signal
+
+TikTok 2026 runs ASR over the spoken track and indexes the transcript
+alongside captions and hashtags. This makes the voiceover a search surface, not
+just an accessibility layer. Practical consequences:
+
+- The hook keyword (product category, price band, audience cue, pain point)
+  has to be **spoken** in the first 5 seconds, not only shown. The project's
+  script templates already require this in line one.
+- Clear diction beats stylized delivery for the indexable portion. A muddy or
+  over-processed voice degrades the transcript and the search match.
+- Original spoken audio can itself become discoverable. A borrowed trending
+  song indexes as the song, not as your product.
+
+## 2. Voiceover and music levels
+
+Mix targets converge across audio-for-video guidance:
+
+| Element | Level | Notes |
+|---|---|---|
+| Voiceover / narration | -3 to -6 dB peak | The foreground. Compress lightly for consistent level. |
+| Integrated loudness (voice) | ~-14 LUFS | Matches streaming/social loudness norms |
+| Music under voice | -25 to -30 dB | 18-24 dB below the voiceover |
+| Music in voice-free beats | -6 to -10 dB | Intro sting, outro, B-roll moments |
+| Sound effects (caption pops) | ~-18 dB rel. voice | Only on emphasized words, not every segment |
+
+**Ducking** (sidechain: music level keyed to the presence of voice) is the
+clean way to hold the gap. The music drops automatically when narration starts
+and recovers in the gaps, instead of a fixed low level for the whole clip.
+
+**`silence_min_duration_sec` is a trim knob, not a level knob.** Audio
+trimming and music ducking are separate concerns; see the audio module notes in
+CLAUDE.md for the trimming semantics.
+
+## 3. Trending sound vs. original audio
+
+The trending-sound playbook fits dance/lip-sync/meme content. Product video is
+narration-led, so the trade-off is different:
+
+- **Original audio (voiceover) is the default.** The viewer needs to hear the
+  product claim, the price, and the CTA. A song can't carry that.
+- **Trending sound has a 3-7 day window.** Its algorithmic lift decays fast and
+  only applies if you ride it early. For an evergreen product review, the song
+  dates the video.
+- **A low trending bed under the voice** is a middle path: it picks up some of
+  the trend signal without burying the narration. Keep it ducked per section 2.
+- **Licensing matters for a commercial pipeline.** Borrowed commercial music
+  carries takedown and monetization risk. The pipeline's audio providers
+  (Jamendo CC-licensed, Freesound) exist for this reason; see the audio module
+  notes in CLAUDE.md and `config/video_production.yaml`.
+
+## 4. The audio hook
+
+The first 3 seconds need an audio event, not just a visual one:
+
+- A spoken punchline that states the concrete fact (matches the punchline-first
+  visual opener).
+- A beat drop or musical accent on the cut to motion.
+- A recognizable sound effect tied to the product (a click, a pour, a snap).
+
+Align the audio hook with the visual hook and the burned-in hook overlay so the
+opening beat lands once, hard, across all three channels (audio, on-screen
+text, caption). Mismatched audio and visual hooks split attention in the
+1.7-second decision window.
+
+## 5. Platform loudness normalization
+
+Each platform normalizes loudness on playback. Master near the platform target
+so the video isn't pushed up or down relative to the surrounding feed:
+
+- Target roughly **-14 LUFS integrated** as a cross-platform compromise.
+- True peak below **-1 dBTP** to avoid clipping after platform transcoding.
+- Don't over-compress to chase loudness; the platforms attenuate it back down
+  and the only audible result is a flatter, more fatiguing track.
+
+## 6. Honest gaps in the evidence
+
+- **Exact platform loudness targets drift and aren't all published.** -14 LUFS
+  is a defensible cross-platform compromise, not an official spec for each app.
+- **"Trending sound boosts reach by X%" numbers are vendor claims**, not
+  controlled trials, and almost all come from non-narration content. Treat the
+  3-7 day window as directional.
+- **ASR transcript weighting is asserted by TikTok**, not independently
+  measured. The defensible posture: clear spoken keywords can only help, so
+  prioritize diction over stylization in the indexable opening.
+
+---
+
+## Sources
+
+- [Brandwatch -- TikTok voiceovers guide (2026)](https://www.brandwatch.com/blog/tiktok-voiceovers/)
+- [Gumlet -- Audio levels for video: dB guide](https://www.gumlet.com/learn/audio-levels-for-video/)
+- [Metricool -- TikTok trends 2026](https://metricool.com/tiktok-trends/)

--- a/docs/audio-best-practices.md
+++ b/docs/audio-best-practices.md
@@ -67,17 +67,17 @@ Mix targets converge across audio-for-video guidance:
 | Music in voice-free beats | -6 to -10 dB | Intro sting, outro, B-roll moments |
 | Sound effects (caption pops) | ~-18 dB rel. voice | Only on emphasized words, not every segment |
 
-**Pipeline mapping.** The producer holds music at a fixed level for the whole
-clip via `audio_settings.music_volume_db` (default -24.0) in
-`config/video_production.yaml`, with the voiceover at `voiceover_volume_db`
-(default 0.0). The default -24.0 sits at the top of the "music under voice"
-band above. Fades are `music_fade_in_duration` / `music_fade_out_duration`.
+**Pipeline mapping.** Levels live in `audio_settings` in
+`config/video_production.yaml`: `music_volume_db` (default -24.0) and
+`voiceover_volume_db` (default 3.0). The -24.0 music level sits at the top of
+the "music under voice" band above. Fades are `music_fade_in_duration` /
+`music_fade_out_duration`.
 
-**Ducking** (sidechain: music level keyed to the presence of voice) is the
-cleaner approach: the music drops automatically when narration starts and
-recovers in the gaps, instead of a fixed low level for the whole clip. The
-pipeline does not do sidechain ducking today (the fixed `music_volume_db` is
-the current model); a voice-keyed duck is a future improvement.
+**Ducking** (music level keyed to the presence of voice) keeps the gap clean:
+the music drops when narration plays and recovers in the gaps, instead of one
+fixed level for the whole clip. The assembler's audio builder
+(`src/video/assembler/audio_builder.py`) builds the FFmpeg ducking and mixing
+filter chains.
 
 **`silence_min_duration_sec` is a trim knob, not a level knob.** Audio
 trimming and music ducking are separate concerns; see the audio module notes in

--- a/docs/audio-best-practices.md
+++ b/docs/audio-best-practices.md
@@ -67,9 +67,17 @@ Mix targets converge across audio-for-video guidance:
 | Music in voice-free beats | -6 to -10 dB | Intro sting, outro, B-roll moments |
 | Sound effects (caption pops) | ~-18 dB rel. voice | Only on emphasized words, not every segment |
 
+**Pipeline mapping.** The producer holds music at a fixed level for the whole
+clip via `audio_settings.music_volume_db` (default -24.0) in
+`config/video_production.yaml`, with the voiceover at `voiceover_volume_db`
+(default 0.0). The default -24.0 sits at the top of the "music under voice"
+band above. Fades are `music_fade_in_duration` / `music_fade_out_duration`.
+
 **Ducking** (sidechain: music level keyed to the presence of voice) is the
-clean way to hold the gap. The music drops automatically when narration starts
-and recovers in the gaps, instead of a fixed low level for the whole clip.
+cleaner approach: the music drops automatically when narration starts and
+recovers in the gaps, instead of a fixed low level for the whole clip. The
+pipeline does not do sidechain ducking today (the fixed `music_volume_db` is
+the current model); a voice-keyed duck is a future improvement.
 
 **`silence_min_duration_sec` is a trim knob, not a level knob.** Audio
 trimming and music ducking are separate concerns; see the audio module notes in

--- a/docs/audio-best-practices.md
+++ b/docs/audio-best-practices.md
@@ -76,8 +76,9 @@ the "music under voice" band above. Fades are `music_fade_in_duration` /
 **Ducking** (music level keyed to the presence of voice) keeps the gap clean:
 the music drops when narration plays and recovers in the gaps, instead of one
 fixed level for the whole clip. The assembler's audio builder
-(`src/video/assembler/audio_builder.py`) builds the FFmpeg ducking and mixing
-filter chains.
+(`src/video/assembler/audio_builder.py`) currently mixes music at the fixed
+`music_volume_db` with fade in/out, not a voice-keyed sidechain duck. A real
+sidechain duck (FFmpeg `sidechaincompress`) is a future improvement.
 
 **`silence_min_duration_sec` is a trim knob, not a level knob.** Audio
 trimming and music ducking are separate concerns; see the audio module notes in

--- a/docs/platform-safe-zones.md
+++ b/docs/platform-safe-zones.md
@@ -1,69 +1,117 @@
 # Platform Safe Zones for Vertical Video (9:16)
 
-Reference for UI overlay areas on TikTok, YouTube Shorts, and Instagram Reels. All measurements are for a **1080x1920** frame.
+Last updated: 2026-05-31
 
-## Per-Platform UI Overlays
+Canonical reference for UI overlay areas on TikTok, YouTube Shorts, and
+Instagram Reels. All measurements are for a **1080x1920** frame. This is the
+single source of truth for safe-zone numbers in the project. The subtitle and
+promotional best-practices docs cite this file rather than carry their own
+copies, and the runtime `PlatformSafeZone` defaults
+(`src/video/config/constants.py`) track the unified rect below.
+
+**Related docs**:
+- [subtitle-best-practices.md](subtitle-best-practices.md) -- caption design;
+  defers to this file for placement bounds.
+- [promotional-video-best-practices.md](promotional-video-best-practices.md)
+  -- promo strategy; defers to this file for the disclosure-corner and CTA
+  placement zones.
+
+## What changed in 2026
+
+Two platform updates moved the numbers since the first version of this doc:
+
+- **Meta unified Reels and Stories safe zones (March 2026)** to **14% top /
+  35% bottom / 6% sides**. The 35% bottom is the big one: Reels now reserves
+  ~670px at the bottom for the caption, follow button, and audio label, far
+  more than the older ~320px pixel guidance.
+- **TikTok added an "Add to Playlist" button (January 2026)** at bottom-right,
+  widening the right-side dead zone by ~20px.
+
+The net effect: the top margin is now driven by Instagram (270px), and the
+bottom margin is driven by Instagram too (670px), not by TikTok as before.
+
+## Per-platform UI overlays
+
+Numbers are the reserved (unsafe) zones. Ranges reflect organic vs. ad/expanded
+states; design to the larger value.
 
 ### TikTok
 
 | Zone | Pixels | % of frame | UI elements |
 |------|--------|------------|-------------|
-| Top | 0-160px | 0-8% | Username, sound label, "Following" indicator |
-| Bottom | 1440-1920px | 75-100% | Caption, hashtags, music ticker, nav bar |
-| Right | 840-1080px | 78-100% width | Like, comment, bookmark, share, music disc |
-| Left | 0-120px (bottom only) | 0-11% width | Username, caption text (bottom-left) |
+| Top | 0-140px | 0-7% | Username, sound label, "Following" indicator |
+| Bottom | 1440-1920px | 75-100% | Caption, hashtags, music ticker, nav (organic ~320px; with CTA/long caption up to ~480px) |
+| Right | 900-1080px | 83-100% width | Like, comment, bookmark, share, music disc, playlist button (Jan 2026) |
+| Left | 0-60px | 0-6% width | Username, caption text (bottom-left) |
 
-TikTok is the most aggressive platform. The right-side engagement buttons span roughly y=600 to y=1500. The bottom overlay height depends on caption length (short: ~250px, long with hashtags: ~480px).
+Right-side buttons span roughly y=600 to y=1500.
 
 ### YouTube Shorts
 
 | Zone | Pixels | % of frame | UI elements |
 |------|--------|------------|-------------|
-| Top | 0-200px | 0-10% | Status bar, "Shorts" label, search, camera |
-| Bottom | 1470-1920px | 77-100% | Channel name, subscribe, title, music, progress bar |
-| Right | 888-1080px | 82-100% width | Like, dislike, comment, share, remix, avatar |
-| Left | mostly clear | - | ~48-60px margin recommended |
+| Top | 0-120px | 0-6% | Status bar, "Shorts" label, search |
+| Bottom | 1620-1920px | 84-100% | Channel name, subscribe, title, music, progress bar (expands to ~400px when description open) |
+| Right | 930-1080px | 86-100% width | Like, dislike, comment, share, remix, avatar |
+| Left | mostly clear | - | ~50-60px margin recommended |
 
-The description area expands to ~480px from bottom when tapped. Right-side buttons span roughly y=900 to y=1550.
+Lightest UI of the three, but still center-biased. Right buttons span roughly
+y=900 to y=1550.
 
-### Instagram Reels
+### Instagram Reels (Meta unified, March 2026)
 
 | Zone | Pixels | % of frame | UI elements |
 |------|--------|------------|-------------|
-| Top | 0-130px | 0-7% | Status bar, "Reels" header, camera icon |
-| Bottom | 1550-1920px | 81-100% | Username, follow, caption, audio bar, nav |
-| Right | 980-1080px | 91-100% width | Like, comment, share, save, menu |
-| Left | mostly clear | - | Caption text appears bottom-left below y=1550 |
+| Top | 0-270px | 0-14% | Status bar, "Reels" header, camera icon |
+| Bottom | 1250-1920px | 65-100% | Username, follow, caption, audio bar, nav (Meta unified 35% interactive zone) |
+| Right | 960-1080px | 89-100% width | Like, comment, share, save, menu |
+| Left | mostly clear | - | ~60px margin |
 
-Instagram has the smallest bottom overlay of the three platforms. Right-side buttons span roughly y=600 to y=1550.
+Reels now has the **largest** top and bottom reserves of the three platforms,
+a reversal from earlier guidance where its bottom was the smallest.
 
-## Unified Cross-Platform Safe Zone
+## Unified cross-platform safe zone
 
-Taking the worst case from each platform:
-
-```
-Top margin:     200px   (y > 10.4%)    — YouTube Shorts is tallest
-Bottom margin:  1440px  (y < 75.0%)    — TikTok starts lowest
-Left margin:    50px    (x > 4.6%)     — all platforms similar
-Right margin:   840px   (x < 77.8%)    — TikTok buttons extend widest
-
-Safe rectangle: 790 x 1240 px
-```
-
-## Subtitle Placement
-
-The lower-third zone where viewers naturally expect captions, above all platform UI:
+Worst case from each side. A single render that has to work on all three
+platforms must stay inside this rectangle:
 
 ```
-Subtitle sweet spot:  y = 1100-1400px  (57%-73% of frame height)
+Top margin:     270px   (y > 14.1%)   -- Instagram Reels (Meta unified 14%)
+Bottom margin:  670px   (y < 65.1%)   -- Instagram Reels (Meta unified 35%)
+Left margin:    60px    (x >  5.6%)   -- all platforms ~60px
+Right margin:   180px   (x < 83.3%)   -- TikTok engagement column + playlist
+
+Safe rectangle: 840 x 980 px, spanning x=60..900, y=270..1250
 ```
 
-This sits above TikTok's bottom overlay (worst case at y=1440) while staying in the natural reading zone. Keep horizontal extent within x=50 to x=840 to avoid right-side engagement buttons on TikTok.
+The runtime defaults in `src/video/config/constants.py` are the
+fractions for these bounds (`SAFE_ZONE_MIN_X/MAX_X/MIN_Y/MAX_Y`). Keep the two
+in sync; a follow-up issue tracks updating the constants to this 2026 union.
+
+## Subtitle and text placement
+
+The reading zone for captions, above all platform bottom UI and below the top
+header:
+
+```
+Caption band:    y = 900-1150px   (47%-60% of frame height)
+Block center:    y ~ 1000px       (~52%)
+Hard floor:      y = 1250px       (65%) -- nothing important below this on Reels
+Horizontal:      x = 60..900px    -- avoids TikTok right-side buttons
+```
+
+Center-ish placement (around 52%) beats a strict lower-third because the bottom
+35% is now interactive UI on Reels and the bottom 25% on TikTok. Keep the
+lowest caption pixel above y=1250. The disclosure overlay (`#ad`) goes
+top-left or top-right inside the 270px top band, not bottom, so it clears the
+caption zone and the centre-upper hook overlay.
 
 ## Sources
 
-- TikTok ad specs and Strike Social safe zone guide
-- Orson Lord safe zone overlays for Reels, TikTok, Shorts
-- Kapwing YouTube Shorts safe zone reference
-- Kreatli platform safe zone guides (2025-2026)
-- Zeely TikTok safe zones guide
+- [Kreatli -- Safe Zone Hub 2026 (TikTok / Reels / Shorts)](https://kreatli.com/guides/safe-zone-guide)
+- [Kreatli -- TikTok Safe Zone 2026](https://kreatli.com/guides/tiktok-safe-zone)
+- [Kreatli -- Instagram Reels Safe Zone 2026](https://kreatli.com/guides/instagram-reels-safe-zone)
+- [Kreatli -- YouTube Shorts Safe Zone 2026](https://kreatli.com/guides/youtube-shorts-safe-zone)
+- [behaviour.digital -- Meta Reels Safe Zone 14% top / 35% bottom / 6% sides (2026)](https://behaviour.digital/post/meta-reels-safe-zone-14-top-35-bottom-6-sides-the-2026-official-guide)
+- [Zeely -- TikTok safe zones 2026](https://zeely.ai/blog/tiktok-safe-zones/)
+- [Postplanify -- Social media safe zones 2026](https://postplanify.com/blog/social-media-safe-zones-2026-complete-guide)

--- a/docs/promotional-video-best-practices.md
+++ b/docs/promotional-video-best-practices.md
@@ -16,17 +16,20 @@ with sound off.
 - [pycaps-subtitles.md](pycaps-subtitles.md) — pycaps engine reference
   including AI word tagging via Gemini.
 - [platform-safe-zones.md](platform-safe-zones.md) — TikTok / Shorts /
-  Reels UI overlay zones.
+  Reels UI overlay zones (canonical safe-zone numbers).
+- [audio-best-practices.md](audio-best-practices.md) — the sound-on layer:
+  trending audio, voiceover/music mix levels, ducking.
 
 ---
 
-## The 5 promo-video rules that matter (cheat-sheet)
+## The 6 promo-video rules that matter (cheat-sheet)
 
 1. **First-3-second hook is a static title card, not karaoke.** 5-12 words, on screen for the full 1.5-3 s, larger than narration captions. The decision window is ~1.7 s; if the hook is still revealing word-by-word at 1.5 s, the viewer has already swiped. The hook must also land the search keyword in spoken audio within the first 5 s — TikTok 2026 transcribes audio via ASR and indexes the transcript as a primary search signal.
 2. **CTA gets its own staging**, distinct from narration. Pair an early **soft CTA** (3-5 s, neutral) with a **hard CTA** at the end (full-frame, accent color, larger, static, ≥1.5 s on screen). Red/orange beats green in independent A/B tests.
 3. **`#ad` disclosure is a persistent on-frame overlay AND first-line caption text.** FTC requires both. Same font family as captions, ~50-60% size, fixed corner, full-clip duration. Penalties up to $53,088 per violation (2025).
 4. **State at least one trade-off per video.** Trust converts; absolute superlatives ("life-changing", "obsessed") now actively reduce trust in 2025-2026 data. A dedicated downside beat is the strongest trust signal in the de-influencing era — disclosed sponsorships do not depress engagement.
 5. **End with an engagement-bait closing line right before the hard CTA.** Personal and storytelling content closes with a two-option opinion question (comment-fork); analytical and comparison content closes with a debatable but defensible spec claim. The closing line drives comments and saves, both of which feed the algorithm. It is additive to the CTA, not a replacement; generic "Comment YES if..." asks are spam-filtered.
+6. **Keep something moving every 1.5-3 seconds.** Each slide change, punch-in, or text pop resets the attention clock. Hold no single static frame past 4-5 s without a visual change. Younger audiences need the tighter end of the band (cut every 2-4 s); a high-density profile pushes to 1.5-3 s with a transition between slides.
 
 ---
 
@@ -105,7 +108,48 @@ that holds the viewer through the first few beats. The project's script
 templates encode the six patterns as the rule for line one and call out
 the Google-query shape as an explicit anti-pattern.
 
-## 2. Sound-off as the primary audience
+## 2. Cut cadence and motion density
+
+Vertical feeds reward visual energy. A frame that hasn't changed in a few
+seconds reads as "nothing happening" and the viewer swipes. The fix is a steady
+beat of visual change, tuned to the audience.
+
+**Shot-length bands** (vendor-converged across 2026 editing tooling):
+
+| Audience / profile | Cut every | Notes |
+|---|---|---|
+| General short-form | 1.5-3 s | The default high-retention band |
+| Younger / Gen Z feeds | 2-4 s, pushing to 1-2 s on high-energy edits | The algorithm reclassifies into faster feeds; match it |
+| First shot (hook) | change within 1-1.5 s | Signals pace immediately, see section 1 |
+| Hard ceiling | never hold a static frame past 4-5 s | Add a punch-in, cut, B-roll, or text pop |
+
+**Motion within a shot counts as a cut.** A Ken Burns settle-zoom, a punch-in,
+or a text pop resets the attention clock without an actual edit. On static
+product photos the pipeline's pre-motion (section 1) supplies this; on a
+slideshow, the slide change itself is the beat.
+
+**Transition vocabulary**, lightest to heaviest:
+
+- **Hard cut** -- the default. Keeps momentum without drawing attention to
+  itself. Most cuts should be hard cuts.
+- **Whip pan** -- energetic scene-to-scene transition; use sparingly so it
+  stays a pattern interrupt, not a tic.
+- **Zoom punch** -- quick scale-in to emphasize a price, spec, or benefit beat.
+- **J-cut / L-cut** -- audio leads or trails the video edit; smooths a
+  narration handoff so the cut doesn't feel abrupt.
+
+**One transition style per video.** Mirrors the subtitle one-effect rule:
+mixing whip pans, zoom punches, and slides in one clip reads as amateur. Pick
+the cadence and the transition from the profile, not per-slide.
+
+**Pipeline mapping**: the high-density cut profile (`cut_density: high`,
+roadmap 1.4) drops the minimum slide duration to 1.5-3 s and inserts one
+transition between every slide. Keep the slower-cut profile available for
+audiences and platforms where a calmer pace fits. Match cut speed to content
+energy; a calm productivity review and a Gen Z gadget teardown should not share
+a cadence.
+
+## 3. Sound-off as the primary audience
 
 **85% of social video views are sound-off** (Manchester Digital,
 Clicks.video, Zebracat 2025 — number converges across sources). Design
@@ -130,7 +174,7 @@ accessibility layer for the 15%, not the source of truth.
   skip if captions are present (vs. higher skip rates without). Captions
   don't directly boost CTR — they prevent the skip that kills CTR.
 
-## 3. Trust signals & FTC `#ad` disclosure
+## 4. Trust signals & FTC `#ad` disclosure
 
 **FTC compliance (US, 2023-updated Endorsement Guides) is the floor**:
 
@@ -176,7 +220,7 @@ accessibility layer for the 15%, not the source of truth.
 This aligns with the project's trade-off-honesty rule baked into the
 script template prompts (CHANGELOG `0.43.1`).
 
-## 4. Closing-line beat — comment-fork or spec-correction
+## 5. Closing-line beat — comment-fork or spec-correction
 
 One short engagement-bait line, right before the hard CTA, not replacing it.
 TikTok's algorithm rewards comments and saves as primary engagement signals;
@@ -211,7 +255,7 @@ The project's script templates encode comment-fork for personal/storytelling
 templates and spec-correction for analytical/comparison templates. See
 `src/ai/prompts/scripts/` for the per-template Rules block.
 
-## 5. CTA staging — soft + hard, two-stage
+## 6. CTA staging — soft + hard, two-stage
 
 **Wistia State of Video 2025** analyzed 36,000+ video CTAs:
 
@@ -242,7 +286,7 @@ templates and spec-correction for analytical/comparison templates. See
 **Verb choice**: imperative + specific outcome. "Get the $15 fix" beats
 "Shop now". "Link to the bag in bio" beats "Click here".
 
-## 6. AI-content disclosure (platform policy, not FTC)
+## 7. AI-content disclosure (platform policy, not FTC)
 
 YouTube and TikTok treat AI-generated content separately from sponsored
 content. The disclosure surfaces are different and both apply on top of
@@ -267,7 +311,7 @@ the FTC `#ad` overlay above.
 The pipeline already prepends `#ad` to caption text and burns the corner
 disclosure. AI-content disclosure is additive, not a replacement.
 
-## 7. Honest gaps in the evidence
+## 8. Honest gaps in the evidence
 
 The vendor literature on captions and promo video is louder than the
 empirical record. Things to flag rather than assert:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -189,7 +189,7 @@ group degrade to FFmpeg without manual intervention.
 - **Margin** from anchor edge (default 4%)
 - **Horizontal alignment**: left, center (default), right
 - Content-aware positioning relative to actual media bounds
-- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. Cross-platform union: top 220px, bottom 480px, left/right 90px on 1080x1920. Configurable globally in YAML and per-profile via the nested `subtitle_settings.safe_zone` block (only the boundaries that differ need to be set).
+- **Platform safe zone**: boundaries avoid TikTok, YouTube Shorts, and Instagram Reels UI overlays. See `platform-safe-zones.md` for the canonical cross-platform union measurements. Configurable globally in YAML and per-profile via the nested `subtitle_settings.safe_zone` block (only the boundaries that differ need to be set).
 - Both engines enforce the safe zone: FFmpeg clamps subtitle width to safe zone boundaries, pycaps dynamically clamps `max_width_ratio` so centered text never extends past the right-side boundary (TikTok buttons). The clamping is automatic — no manual tuning needed per template.
 - Pycaps default position: bottom of safe zone (~75% of frame). Template's own alignment preserved unless explicitly overridden.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-05-07
+Last updated: 2026-05-31
 
 Forward-looking work on ContentEngineAI, grouped into phases by horizon. Items are aspirational, not commitments. Order within each phase is rough priority.
 
@@ -32,9 +32,15 @@ The foundational items shipped across 0.48.0-0.49.0 (audio-keyword opener, engag
 
 ### 1.4 High-density cut profile
 
-Add a `cut_density: high` profile setting in `config/video_production.yaml` that drops the minimum slide duration to 1.5-3s and adds a transition (whip pan, hard cut, zoom punch) between every slide. Useful for younger audiences on platforms whose feeds reward visual energy density. Keep the existing slow-cut profile available for use cases where it fits better.
+Add a `cut_density: high` profile setting in `config/video_production.yaml` that drops the minimum slide duration to 1.5-3s and adds a transition (whip pan, hard cut, zoom punch) between every slide. Useful for younger audiences on platforms whose feeds reward visual energy density. Keep the existing slow-cut profile available for use cases where it fits better. Strategy and shot-length bands are in `docs/promotional-video-best-practices.md` section 2.
 
 **Done when:** a high-density profile renders without subtitle desync and is selectable per platform.
+
+### 1.6 Cross-platform safe-zone refresh
+
+The safe-zone docs were aligned to 2026 platform specs (`docs/platform-safe-zones.md` is now the canonical source; the subtitle and promo docs cite it). The runtime constants in `src/video/config/constants.py` still carry the older union (top 200 / bottom 1440 / left 50 / right 840). Update them to the 2026 union (top 270 / bottom 1250 / left 60 / right 900 on 1080x1920), driven by Meta's March 2026 Reels unification (14% top, 35% bottom). The current `max_y` of 0.75 lets captions land inside Reels' bottom interactive zone. A single cross-platform render should clamp to the union, not `platform=tiktok` only. Tracked as GitHub issues.
+
+**Done when:** the runtime safe-zone defaults match the canonical doc, and a render's lowest caption pixel stays above y=1250.
 
 ## Phase 2 — Non-affiliate pillar mode (Now/Next)
 
@@ -354,3 +360,8 @@ Backfilled from the changelog (0.1.0 through 0.42.x). Grouped by theme rather th
 **Pillar infrastructure and caption voice (Unreleased)**
 - Keyword-to-pillar attachment in the scraper config. Keywords in `config/scraper.yaml` are a dict keyed by pillar; each scraped product carries the pillar through to the producer and registry without `--pillar`.
 - Narrator profile and pillar preamble shared with platform caption generators (YouTube, TikTok, Instagram) so captions match the video's conversational voice.
+
+**Best-practices docs (Unreleased)**
+- Safe-zone docs aligned to 2026 platform specs. `docs/platform-safe-zones.md` is the canonical source; subtitle and promo docs cite it. Refreshed for Meta's March 2026 Reels unification (14% top, 35% bottom) and TikTok's Jan 2026 playlist button. Runtime constant refresh tracked separately (roadmap 1.6).
+- New `docs/audio-best-practices.md`: the sound-on layer (trending vs original audio, voiceover/music mix levels, ducking, audio hook, platform loudness).
+- New cut-cadence section in `docs/promotional-video-best-practices.md` (shot-length bands, transition vocabulary) backing the high-density cut profile (1.4).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,6 +42,18 @@ The safe-zone docs were aligned to 2026 platform specs (`docs/platform-safe-zone
 
 **Done when:** the runtime safe-zone defaults match the canonical doc, and a render's lowest caption pixel stays above y=1250.
 
+### 1.7 Hook-variant A/B measurement
+
+The cold-open variant framework already selects one of several hook variants per product and writes it to `pipeline_state.json`. Persist that variant into the published-products registry (a `hook_variant` column) and surface it in the analytics reports so per-variant retention is measurable. Hook hold is the primary retention lever; without per-variant data there's no way to learn which opener holds past the 3-second mark. Pairs with the high-density cut profile (1.4) as the two retention experiments. Note this is the measurement layer; 1.2 and 1.4 are the production layers.
+
+**Done when:** the registry carries the hook variant per video and a report segments retention by hook variant.
+
+### 1.8 Loop-friendly ending
+
+Optionally match the final frame to the opening frame so the clip loops seamlessly on autoplay. Replay rate is a ranking signal on short-form feeds. Config flag per profile, off by default.
+
+**Done when:** a profile with the loop flag renders a video whose last frame matches its first within a tolerance, selectable per profile.
+
 ## Phase 2 — Non-affiliate pillar mode (Now/Next)
 
 Targeted for weeks 3-4. The pillar system itself shipped in 0.43.0 (default pillars: `value`, `novelty`, `utility`; keyword pool grouped by pillar in `config/scraper.yaml`; templates mapped to pillars in `config/ai_services.yaml::script_templates.pillars`; `--pillar` flag on both `src/video/producer/cli.py` and `src/pipeline/global_batch.py`; per-pillar preambles and audiences). What's still missing: an opt-out for affiliate URL injection so the same pipeline can carry an educational track.
@@ -92,6 +104,12 @@ Verify the Instagram path in the publisher posts as a Reel, not as a Feed Post. 
 
 **Done when:** the next batch publishes to IG as Reels, confirmed end-to-end, with a test in place to prevent drift.
 
+### 3.7 Pre-production conversion gate in the scraper
+
+Score and filter product candidates before rendering, using the data the scraper already pulls (price, rating, review count, stock, Prime/shipping). Drop weak-converting candidates up front: rating below a floor, thin review count, out of stock, price outside a configurable impulse band. Renders are expensive; spending them on products that won't convert is the largest avoidable waste in the funnel. This sits upstream of the listing-drift diagnostic (5.2), which only monitors drift after publish. Thresholds live in `config/scraper.yaml`.
+
+**Done when:** a scrape run rejects below-threshold products before the producer stage, with the rejection reason logged.
+
 ## Phase 4 — Per-platform optimisations (Next)
 
 Targeted for the following quarter. Builds on Phases 1-3.
@@ -131,6 +149,18 @@ Wrap every Amazon affiliate URL with the OneLink redirect at publish time so non
 Update the link-in-bio integration in `src/publisher/link_in_bio/` so adding a new product rotates the featured slot rather than appending. Industry baseline: link-in-bio hubs see 20-40% click-through to the top destination URL when only 2-3 links are present; the first 3 positions get ~130% higher CTR than positions 4-10. Cap the bio at the most recent featured product plus an "all products" fallback.
 
 **Done when:** the bio shows at most 2-3 links at any time, with the most recent product as the featured slot.
+
+### 4.7 Cover / poster-frame generation
+
+Generate a cover frame for each video (hero product image plus a bold three-word title) and set it as the poster frame. The Shorts/Reels grid and the profile page drive browse-tab click-through and the follow decision; right now nothing controls the thumbnail. Reuses the hook text and the product image the producer already has.
+
+**Done when:** every render produces a cover image and the publish payload sets it as the poster where the platform supports it.
+
+### 4.8 Episodic series framing per pillar
+
+Add a per-pillar counter to the registry and thread it into title/caption templates (for example "Pillar pick #12"). Series framing is a documented return-viewership driver and targets the follower/subscriber conversion gap. Builds on the existing pillar system.
+
+**Done when:** published titles/captions carry a per-pillar episode number that increments across the back-catalogue.
 
 ## Phase 5 — Analytics and continuous learning (Next)
 

--- a/docs/subtitle-best-practices.md
+++ b/docs/subtitle-best-practices.md
@@ -35,8 +35,8 @@ Open follow-up work is tracked as GitHub Issues with the `subtitles` and
 5. **Max 3–5 words on screen, max 2 lines**. Break on phrase boundaries, never mid-phrase.
 6. **Sentence case, not ALL CAPS** (mixed case reads faster — ascenders/descenders carry word shape). ALL CAPS only for deliberate shout-style.
 7. **15–17 CPS (~170 WPM)** reading speed. Minimum 500–600 ms per segment.
-8. **Vertical center (45–60% from top)**, not lower-third. TikTok's UI eats the bottom 480 px.
-9. **Design to TikTok's safe zone**: top 220 / bottom 480 / right 180. Works on Shorts and Reels automatically.
+8. **Vertical center, block centered around 52% from top**, not lower-third. Keep the lowest caption pixel above y=1250 (65%). See [platform-safe-zones.md](platform-safe-zones.md).
+9. **Design to the cross-platform union**: top 270 / bottom 670 / right 180 on a 1080x1920 canvas (Instagram drives top and bottom after Meta's March 2026 change). Canonical numbers live in [platform-safe-zones.md](platform-safe-zones.md).
 10. **Entrance 100–250 ms, no exit animation**. Use ease-out-quint (`cubic-bezier(0.22, 1, 0.36, 1)`).
 11. **Strip terminal punctuation** — karaoke segment breaks ARE the punctuation.
 12. **Smooth Whisper timings**: merge gaps <80 ms, min word duration 120 ms, hold last word +200 ms, lead audio by 40 ms.
@@ -186,28 +186,24 @@ only trigger on emphasized words — every-word SFX becomes fatiguing fast.
 
 ## 4. Layout and positioning
 
-**Vertical position: 45–60% from top** (roughly center, slightly above
-center). This survives TikTok's bottom UI overlay, Reels' caption sticker,
-and Shorts' progress bar simultaneously. Center-ish outperforms strict
-lower-third because TikTok's UI controls occupy the bottom 480 px of a
-1920-tall frame.
+**Vertical position: block centered around 52% from top** (roughly center,
+slightly above center). This survives TikTok's bottom UI overlay, Reels'
+caption zone, and Shorts' progress bar simultaneously. Center-ish outperforms
+strict lower-third because the bottom is now interactive UI: 35% on Reels
+(Meta unified, March 2026) and ~25% on TikTok.
 
-**Safe zones** (union of all three platforms):
+**Safe zones**: see [platform-safe-zones.md](platform-safe-zones.md) for the
+canonical per-platform tables and the cross-platform union. The summary, for a
+1080x1920 canvas:
 
-| Platform | Top | Bottom | Right |
+| | Top | Bottom | Right |
 |---|---|---|---|
-| TikTok | 160 px | 480 px (ads: ~600 px) | 180 px |
-| YouTube Shorts | 120 px | 300 px (expanded: ~400 px) | 84 px |
-| Instagram Reels | 220 px | 450 px | 84 px |
+| Union (single render) | 270 px | 670 px | 180 px |
 
-**Design to the union**: top 220 px, bottom 480 px, left/right 90 px on a
-1080×1920 canvas. Caption center Y between **860–1100 px**. One design
-covers all three platforms.
-
-**Single-rectangle fallback** when a template ships one design that has
-to work on all three: centre **888×1160 px** on the 1080×1920 canvas
-(Kreatli cross-platform intersection). Use as the conservative bound
-when per-platform safe-zone tuning is not available.
+Instagram drives both top and bottom after the March 2026 Meta change. Caption
+band y=900-1150, block center ~y=1000 (~52%), hard floor y=1250 (65%),
+horizontal x=60..900. One design covers all three platforms. Defer to the
+canonical doc when the numbers here and there ever diverge.
 
 **Line break strategy**: 3–5 words per line, max 2 lines on screen. Break
 on natural phrase boundaries (after verbs, before prepositions) — never
@@ -258,12 +254,14 @@ colorful, karaoke.
 Keep bottom 300 px clear (expand to 400 px when description is open).
 Shorts' AI captions are plainer — your custom design differentiates.
 
-**Instagram Reels**: tightest top margin (220 px eaten by username/music).
-IG's native caption sticker has a specific look that viewers associate
-with "lazy creator" — custom captions should look clearly more intentional.
+**Instagram Reels**: after Meta's March 2026 unification, the tightest margins
+on both ends (270 px top, 670 px bottom). IG's native caption sticker has a
+specific look that viewers associate with "lazy creator" -- custom captions
+should look clearly more intentional.
 
-**Cross-platform rule**: design to TikTok's safe zone (tightest bottom).
-Center-Y around 960–1050 px. One template, three platforms.
+**Cross-platform rule**: design to the union; Instagram now drives both top and
+bottom. Block center-Y around 1000 px (~52%), lowest pixel above y=1250. One
+template, three platforms. See [platform-safe-zones.md](platform-safe-zones.md).
 
 ## 7. What the pros ship
 
@@ -397,8 +395,10 @@ placed at end of phrase.
 **Segment rules**: 3–5 words per segment, 600–1800 ms duration, break on
 sentence/phrase boundaries not word count alone.
 
-**Safe zone**: designed to TikTok (tightest union) — top 220 / bottom 480 /
-right 180. Single render covers all three platforms.
+**Safe zone**: designed to the cross-platform union -- top 270 / bottom 670 /
+right 180 on 1080x1920 (Instagram drives top and bottom after Meta's March 2026
+change). Block center ~y=1000, lowest pixel above y=1250. Single render covers
+all three platforms. See [platform-safe-zones.md](platform-safe-zones.md).
 
 **Accessibility**: ~21:1 contrast, WCAG AAA. No flashes, scale pulses
 capped at 1.10.

--- a/docs/subtitle-best-practices.md
+++ b/docs/subtitle-best-practices.md
@@ -19,7 +19,9 @@ large fraction of viewers they *are* the content.
 - [pycaps-subtitles.md](pycaps-subtitles.md) — pycaps engine reference
   including AI word tagging via Gemini.
 - [platform-safe-zones.md](platform-safe-zones.md) — TikTok / Shorts /
-  Reels UI overlay zones.
+  Reels UI overlay zones (canonical safe-zone numbers).
+- [audio-best-practices.md](audio-best-practices.md) — the sound-on layer
+  (trending vs original audio, voiceover/music levels, ducking).
 
 Open follow-up work is tracked as GitHub Issues with the `subtitles` and
 `pycaps` labels.


### PR DESCRIPTION
Doc-only iteration. Aligns the safe-zone docs to 2026 platform specs, fills two best-practices gaps, and adds engagement/conversion roadmap items.

## What changed
- `platform-safe-zones.md` is now the canonical safe-zone source. Refreshed for Meta's March 2026 Reels/Stories unification (14% top, 35% bottom) and TikTok's Jan 2026 playlist button. Added per-platform tables, the cross-platform union, a caption band, sources, and a last-updated line.
- `subtitle-best-practices.md` cites the canonical doc instead of carrying divergent numbers (rules 8/9, the section 4 table, section 6, starter recipe).
- `promotional-video-best-practices.md` gains a cut-cadence section (shot-length bands, transition vocabulary) and a 6th cheat-sheet rule.
- New `audio-best-practices.md`: the sound-on layer (trending vs original audio, voiceover/music levels, ducking, audio hook, platform loudness).
- `roadmap.md`: item 1.6 (safe-zone constant follow-up) plus five new items from a retention/conversion analysis -- 1.7 hook-variant A/B measurement, 1.8 loop-friendly ending, 3.7 pre-production conversion gate in the scraper, 4.7 cover/poster-frame generation, 4.8 episodic series framing per pillar. Each carries a shipped note for the doc work.
- README links the new audio doc; CHANGELOG gets a Documentation entry.
- `.gitignore` ignores `.playwright-mcp/` runtime captures.

## Why
The safe-zone reference disagreed with the subtitle doc and both were stale against 2026 platform UI. The promo doc had no cut-cadence guidance and there was no audio doc. The five roadmap items target the two measured bottlenecks: hook hold (retention) and product selection (conversion).

## Follow-up (code, not in this PR)
Refs #140 (refresh runtime safe-zone constants to the 2026 union; `max_y` 0.75 lets captions land in Reels' bottom UI). Refs #141 (single cross-platform render should clamp to the union, not platform=tiktok).

## How to test
Docs only. Safe-zone numbers match across all three docs and the canonical source; new roadmap items carry done-when criteria.
