### PR TITLE
Housekeeping: sort_order default, base-pool exclusion, log level, docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.1] - 2026-06-10
+
 ### Fixed
 - Global batch no longer logs an invalid `sort_order` warning on every scrape. The Amazon search-parameters default was the CLI-friendly `relevance` instead of the Amazon token `relevanceblender`, so the batch's default filters failed validation.
 - Random profile selection no longer picks the `base` profile. It's the inheritance template, not a render target, and stays available via an explicit `--profile` / `--batch-profile`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Global batch no longer logs an invalid `sort_order` warning on every scrape. The Amazon search-parameters default was the CLI-friendly `relevance` instead of the Amazon token `relevanceblender`, so the batch's default filters failed validation.
+- Random profile selection no longer picks the `base` profile. It's the inheritance template, not a render target, and stays available via an explicit `--profile` / `--batch-profile`.
+- The "two-part subtitles not supported in pycaps mode" notice is now DEBUG instead of a WARNING on every pycaps run.
+
+### Documentation
+- `audio_builder` docstrings corrected: it mixes audio at fixed levels (FFmpeg amix), not sidechain ducking.
+
 ## [0.52.0] - 2026-06-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,9 @@ Security-critical updates can trigger an immediate patch release without waiting
 
 **CRITICAL**: Standalone module CLIs (publisher, scraper, producer) and `global_batch.py` often have parallel implementations of the same logic (scheduling, validation, retry, cleanup). When fixing or adding behavior in one path, **proactively check the other path** for the same issue or missing feature. Don't wait for it to break separately. The batch pipeline re-implements logic from standalone modules rather than calling them, so drift is common and silent.
 
+- **The random profile-pool "all profiles" fallback exists in FOUR places**: `src/video/producer/utils.py::load_profile_pool`, two spots in `src/pipeline/global_batch.py`, and `src/pipeline/config.py::validate_global_batch_config`. The last one is the one that actually matters for the batch: it populates an empty `config.profile_pool` with the profile list, and that populated pool is what `select_profile_for_product` selects from. The two `global_batch.py` spots build local pools used elsewhere. So a change to "which profiles are random-selectable" (e.g. excluding `base`) has to land in `config.py` too, or the batch keeps using the old set. Grep all four for `video_profiles` when touching random selection.
+- **Two `SearchParameters` classes hold the same concept**: `src/scraper/config_models.py` (Pydantic) and `src/scraper/amazon/models.py` (dataclass extending `BaseSearchParameters`). The global batch's `scraper_filters` uses the dataclass one; its defaults can drift from the Pydantic one (the `sort_order` default did: dataclass inherited the base's `"relevance"`, Pydantic had `"relevanceblender"`). When changing a search-param default, change both or confirm which path consumes it.
+
 ## Available MCP Servers
 
 The project has access to these MCP servers for enhanced development capabilities:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -356,6 +356,7 @@ Group products and scripts into a small set of named pillars (default 3). Each k
 
 ### Profile Randomization
 - Random profile selection per product from configured pool
+- When no pool is configured, the fallback is all profiles except `base` (the inheritance template, not a render target); `base` is still usable via an explicit profile choice
 - Deterministic seeding for reproducibility
 - Profile compatibility checking with skip on mismatch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ContentEngineAI"
-version = "0.52.0"
+version = "0.52.1"
 description = "AI-powered content automation pipeline for e-commerce platforms"
 authors = ["ContentEngineAI Team <stkzlv+ContentEngineAI@gmail.com>"]
 license = "MIT"

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -952,9 +952,16 @@ def validate_global_batch_config(
 
     # Validate random profile configuration
     if config.random_profile:
-        # If no profile pool specified, use all available profiles
+        # If no profile pool specified, use all available render profiles
+        # (excluding `base`, the inheritance template).
         if not config.profile_pool:
-            config.profile_pool = list(video_config.video_profiles.keys())
+            from src.video.producer.utils import EXCLUDED_RANDOM_PROFILES
+
+            config.profile_pool = [
+                p
+                for p in video_config.video_profiles
+                if p not in EXCLUDED_RANDOM_PROFILES
+            ]
 
         # Validate all profiles in pool exist
         invalid_profiles = [

--- a/src/pipeline/global_batch.py
+++ b/src/pipeline/global_batch.py
@@ -430,9 +430,13 @@ class GlobalPipelineOrchestrator:
             return None
 
         if self.config.random_profile:
-            pool = self.config.profile_pool or list(
-                self.video_config.video_profiles.keys()
-            )
+            from src.video.producer.utils import EXCLUDED_RANDOM_PROFILES
+
+            pool = self.config.profile_pool or [
+                p
+                for p in self.video_config.video_profiles
+                if p not in EXCLUDED_RANDOM_PROFILES
+            ]
             for name in pool:
                 profile = self.video_config.video_profiles.get(name)
                 if profile and not profile.use_scraped_videos:
@@ -545,8 +549,14 @@ class GlobalPipelineOrchestrator:
                 print(f"    - Strategy: {profile.strategy}")
                 print(f"    - Resolution: {profile.resolution}")
         elif self.config.random_profile:
+            from src.video.producer.utils import EXCLUDED_RANDOM_PROFILES
+
             print("  Profile mode: Random selection")
-            pool = self.config.profile_pool or list(video_config.video_profiles.keys())
+            pool = self.config.profile_pool or [
+                p
+                for p in video_config.video_profiles
+                if p not in EXCLUDED_RANDOM_PROFILES
+            ]
             print(f"  Profile pool ({len(pool)} profiles):")
             for p in pool[:5]:
                 print(f"    - {p}")

--- a/src/scraper/amazon/models.py
+++ b/src/scraper/amazon/models.py
@@ -71,6 +71,10 @@ class SearchParameters(BaseSearchParameters):
 
     # Amazon-specific fields
     prime_only: bool = False
+    # Override the generic base default ("relevance") with the Amazon sort
+    # token. validate() and build_search_url() expect an Amazon token; the
+    # CLI --sort maps friendly names, but the global batch uses this default.
+    sort_order: str = "relevanceblender"
 
     def __post_init__(self):
         """Initialize Amazon search parameters."""

--- a/src/video/assembler/audio_builder.py
+++ b/src/video/assembler/audio_builder.py
@@ -1,7 +1,8 @@
 """Audio filter chain construction.
 
 This module provides utilities for building FFmpeg audio filter chains with
-support for voiceover, background music, ducking, and video audio mixing.
+support for voiceover, background music, and video audio. Tracks are combined
+with fixed-level mixing (FFmpeg amix, normalize off), not sidechain ducking.
 """
 
 import logging
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class AudioFilterBuilder:
-    """Build FFmpeg audio filter chains with ducking and mixing.
+    """Build FFmpeg audio filter chains with fixed-level mixing.
 
     This class handles construction of complex audio filter graphs for FFmpeg,
     including voiceover processing, background music with fades, and optional

--- a/src/video/producer/steps.py
+++ b/src/video/producer/steps.py
@@ -860,7 +860,7 @@ async def step_generate_subtitles(ctx: PipelineContext):
 
         if subtitle_engine == "pycaps":
             if two_part_enabled:
-                logger.warning(
+                logger.debug(
                     "Two-part subtitles are not supported in pycaps mode. "
                     "Disabling two-part for this run; re-enable by switching "
                     "subtitle_engine back to 'ffmpeg'."

--- a/src/video/producer/utils.py
+++ b/src/video/producer/utils.py
@@ -12,6 +12,11 @@ from src.video.config import VideoConfig
 
 logger = logging.getLogger(__name__)
 
+# Profiles excluded from random selection. `base` is the inheritance template
+# other profiles extend, not a render target, so random batches shouldn't pick
+# it. It stays usable via an explicit --profile / --batch-profile.
+EXCLUDED_RANDOM_PROFILES = frozenset({"base"})
+
 
 def setup_logging(config: VideoConfig, debug_mode: bool = False) -> Path:
     """Set up logging to both console and file.
@@ -339,8 +344,8 @@ def load_profile_pool(
     elif yaml_pool is not None and len(yaml_pool) > 0:
         pool = yaml_pool
     else:
-        # Default to all available profiles
-        pool = list(config.video_profiles.keys())
+        # Default to all available profiles, minus non-render templates.
+        pool = [p for p in config.video_profiles if p not in EXCLUDED_RANDOM_PROFILES]
 
     # Validate all profiles exist
     validate_profiles(pool, config)

--- a/tests/scraper/test_amazon_search_params.py
+++ b/tests/scraper/test_amazon_search_params.py
@@ -1,0 +1,18 @@
+"""Tests for the Amazon SearchParameters dataclass defaults.
+
+This is `src.scraper.amazon.models.SearchParameters` (the dataclass the global
+batch uses via scraper_filters), not the Pydantic `config_models` one.
+"""
+
+from src.scraper.amazon.models import SearchParameters
+
+
+def test_default_sort_order_is_valid_amazon_token():
+    # The global batch builds scraper_filters from this bare default, so the
+    # default must be a valid Amazon token, not the CLI-friendly "relevance".
+    params = SearchParameters()
+    assert params.sort_order == "relevanceblender"
+
+
+def test_default_params_validate_cleanly():
+    assert SearchParameters().validate() == []

--- a/tests/test_global_batch_config.py
+++ b/tests/test_global_batch_config.py
@@ -168,3 +168,30 @@ class TestPillarOverride:
         cli = _make_cli()
         config = load_global_batch_config(cli, config_path=yaml_with_keywords)
         assert config.pillar is None
+
+
+def test_random_profile_pool_excludes_base():
+    """validate_global_batch_config drops base from the all-profiles fallback.
+
+    base is the inheritance template, not a render target, so a random batch
+    with no explicit pool must not select it.
+    """
+    from unittest.mock import Mock
+
+    from src.pipeline.config import GlobalBatchConfig, validate_global_batch_config
+
+    video_config = Mock()
+    video_config.video_profiles = {
+        "base": Mock(),
+        "slideshow_images1": Mock(),
+        "video_sequential": Mock(),
+    }
+    config = GlobalBatchConfig(random_profile=True)
+    config.product_ids = ["B0TESTASIN"]
+    config.skip_publish = True
+    config.profile_pool = []
+
+    validate_global_batch_config(config, video_config)
+
+    assert "base" not in config.profile_pool
+    assert "slideshow_images1" in config.profile_pool

--- a/tests/video/producer/test_profile_selection.py
+++ b/tests/video/producer/test_profile_selection.py
@@ -157,6 +157,15 @@ class TestLoadProfilePool:
 
         assert set(result) == set(mock_config.video_profiles.keys())
 
+    def test_base_excluded_from_all_profiles_fallback(self, mock_config):
+        """Base is the inheritance template, never picked by random selection."""
+        mock_config.video_profiles["base"] = Mock()
+
+        result = load_profile_pool(None, None, mock_config)
+
+        assert "base" not in result
+        assert "slideshow_images1" in result
+
     def test_cli_empty_list_overrides_yaml(self, mock_config):
         """Test empty CLI list is respected (returns empty, triggers all later)."""
         cli_pool: list[str] = []


### PR DESCRIPTION
## Summary
Four small, independent housekeeping fixes.

## Changes
- **#147** Amazon `SearchParameters` default `sort_order` changed from the CLI-friendly `relevance` to the Amazon token `relevanceblender`. The global batch builds its default filters from this bare default, so every scrape logged a validation warning and the sort wasn't applied. (Note: the Pydantic `config_models.SearchParameters` already had the right default; this fixes the dataclass `amazon.models` one the batch uses.)
- **#148** Exclude `base` from random profile selection. It's the inheritance template, not a render target. Added a shared `EXCLUDED_RANDOM_PROFILES` constant and applied it at all the all-profiles fallback sites: `pipeline/config.py` (which populates the empty random pool the batch actually selects from), producer `load_profile_pool`, and two in `global_batch`. `base` stays usable via an explicit `--profile` / `--batch-profile`.
- **#117** Demote the "two-part subtitles not supported in pycaps mode" notice from WARNING to DEBUG (it fires on every pycaps run).
- **#143** Fix `audio_builder` docstrings: it mixes audio at fixed levels (FFmpeg amix), not sidechain ducking.

## Test
`poetry run pytest tests/scraper/ tests/video/ tests/pipeline/`. New tests: `SearchParameters()` default validates cleanly; `load_profile_pool` excludes `base` from the all-profiles fallback.

Closes #147
Closes #148
Closes #117
Closes #143